### PR TITLE
Fix a typo in the seed annotation key

### DIFF
--- a/charts/oidc-apps-controller/templates/_helpers.tpl
+++ b/charts/oidc-apps-controller/templates/_helpers.tpl
@@ -103,7 +103,7 @@ Create the name of the cluster role to use
 Returns a clientId by seed name
 */}}
 {{- define "oidc-apps-extension.fetchClientIdBySeedIdentifier" }}
-  {{- $clientName := get .Values.gardener.seed.annotations "odic-apps.extensions.gardener.cloud/client-name" }}
+  {{- $clientName := get .Values.gardener.seed.annotations "oidc-apps.extensions.gardener.cloud/client-name" }}
   {{- $clientID := "" }}
   {{- range .Values.clients }}
     {{- if eq .name $clientName }}

--- a/charts/oidc-apps-controller/values.yaml
+++ b/charts/oidc-apps-controller/values.yaml
@@ -153,20 +153,11 @@ targets:
       # It overwrites the cluster wide {{configuration}}
       configuration:
 
-# In case of Gardener there can be a mapping between seed names and oidc client ids
+# In case of Gardener, seeds must configure which client ID to be used the client name.
+# They use the annotation key `oidc-apps.extensions.gardener.cloud/client-name`
+# where the value is the logical name of the client.
 clients:
-  # Seed name shall match the seed identifier
-  # - name: app1
-  # clientId shall be the oidc client id configured at the oidc provider
-  #  clientId: 10365f8c-d9ba-44f9-8e85-741e8cc01f9c
+  # - name: app1 # Logical name of the client.
+  #   clientId: 10365f8c-d9ba-44f9-8e85-741e8cc01f9c # clientId shall be the oidc client id configured at the oidc provider
   # - name: app2
   #   clientId : 98a36b69-6592-463a-b605-d4c563f8b016
-
-gardener:
-  # seed:
-  #   name: foo
-  #   annotations:
-  #     odic-apps.extensions.gardener.cloud/client-name: app1
-  #   spec:
-  #     ingress:
-  #       domain: foo.example.com


### PR DESCRIPTION
**What this PR does / why we need it**:
Fix a typo in the seed annotation key.

Also removes the gardener values and improves the documentation of the clients values. 

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user

```
