### PR TITLE
Initial implementation of webhook controller-runtime env test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ VERSION                     := $(shell cat "$(REPO_ROOT)/VERSION")
 EFFECTIVE_VERSION           := $(VERSION)-$(shell git rev-parse HEAD)
 LD_FLAGS                    ?= $(shell $(REPO_ROOT)/hack/get-build-ld-flags.sh k8s.io/component-base $(REPO_ROOT)/VERSION $(BINARY))
 PLATFORM                    := linux/amd64,linux/arm64
-ENVTEST_K8S_VERSION         ?= 1.29.3
+ENVTEST_K8S_VERSION         ?= 1.30.0
 
 ifneq ($(strip $(shell git status --porcelain 2>/dev/null)),)
 	EFFECTIVE_VERSION := $(EFFECTIVE_VERSION)-dirty
@@ -83,7 +83,7 @@ test: $(MOCKGEN)
 
 .PHONY: envtest
 envtest: $(SETUP_ENVTEST)
-	@$(KUBEBUILDER_ASSETS); go test $(REPO_ROOT)/test/... --ginkgo.v -timeout 10m
+	@$(KUBEBUILDER_ASSETS) && go test $(REPO_ROOT)/test/... --ginkgo.v -timeout 10m
 
 .PHONY: add-license-headers
 add-license-headers: $(GO_ADD_LICENSE)

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -25,8 +25,6 @@ const (
 	AnnotationSuffixKey = "oidc-application-controller/suffix"
 	//AnnotationOauth2SecertCehcksumKey holds the checksum of the ouath2 proxy confguration secret
 	AnnotationOauth2SecertCehcksumKey = "oidc-application-controller/oauth2-secret-checksum"
-	//DeploymentWebHookPath is the context path of the mutating webhook for deployments
-	DeploymentWebHookPath = "/oidc-mutate-v1-deployment"
 	//PodWebHookPath is the context path of the mutating webhook for pods
 	PodWebHookPath = "/oidc-mutate-v1-pod"
 	//VpaWebHookPath is the context path of the mutating webhook for pods

--- a/test/e2e/config/oidc-apps.yaml
+++ b/test/e2e/config/oidc-apps.yaml
@@ -1,6 +1,7 @@
 configuration:
   oauth2Proxy:
   kubeRbacProxy:
+  domainName: "example.com"
 targets:
   - name: "nginx"
     labelSelector:

--- a/test/e2e/config/oidc-apps.yaml
+++ b/test/e2e/config/oidc-apps.yaml
@@ -7,5 +7,5 @@ targets:
       matchLabels:
         app: nginx
     ingress:
-      enabled: false
+      enabled: true
       ingressClassName: "nginx"

--- a/test/e2e/crds/vpa-v1-crd-gen.yaml
+++ b/test/e2e/crds/vpa-v1-crd-gen.yaml
@@ -1,0 +1,788 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: verticalpodautoscalercheckpoints.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  names:
+    kind: VerticalPodAutoscalerCheckpoint
+    listKind: VerticalPodAutoscalerCheckpointList
+    plural: verticalpodautoscalercheckpoints
+    shortNames:
+    - vpacheckpoint
+    singular: verticalpodautoscalercheckpoint
+  scope: Namespaced
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
+          state of VPA that is used for recovery after recommender's restart.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the checkpoint. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.'
+            properties:
+              containerName:
+                description: Name of the checkpointed container.
+                type: string
+              vpaObjectName:
+                description: Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                  object.
+                type: string
+            type: object
+          status:
+            description: Data of the checkpoint.
+            properties:
+              cpuHistogram:
+                description: Checkpoint of histogram for consumption of CPU.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              firstSampleStart:
+                description: Timestamp of the fist sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastSampleStart:
+                description: Timestamp of the last sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The time when the status was last refreshed.
+                format: date-time
+                nullable: true
+                type: string
+              memoryHistogram:
+                description: Checkpoint of histogram for consumption of memory.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              totalSamplesCount:
+                description: Total number of samples in the histograms.
+                type: integer
+              version:
+                description: Version of the format of the stored data.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+  - name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VerticalPodAutoscalerCheckpoint is the checkpoint of the internal
+          state of VPA that is used for recovery after recommender's restart.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the checkpoint. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.'
+            properties:
+              containerName:
+                description: Name of the checkpointed container.
+                type: string
+              vpaObjectName:
+                description: Name of the VPA object that stored VerticalPodAutoscalerCheckpoint
+                  object.
+                type: string
+            type: object
+          status:
+            description: Data of the checkpoint.
+            properties:
+              cpuHistogram:
+                description: Checkpoint of histogram for consumption of CPU.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              firstSampleStart:
+                description: Timestamp of the fist sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastSampleStart:
+                description: Timestamp of the last sample from the histograms.
+                format: date-time
+                nullable: true
+                type: string
+              lastUpdateTime:
+                description: The time when the status was last refreshed.
+                format: date-time
+                nullable: true
+                type: string
+              memoryHistogram:
+                description: Checkpoint of histogram for consumption of memory.
+                properties:
+                  bucketWeights:
+                    description: Map from bucket index to bucket weight.
+                    type: object
+                    x-kubernetes-preserve-unknown-fields: true
+                  referenceTimestamp:
+                    description: Reference timestamp for samples collected within
+                      this histogram.
+                    format: date-time
+                    nullable: true
+                    type: string
+                  totalWeight:
+                    description: Sum of samples to be used as denominator for weights
+                      from BucketWeights.
+                    type: number
+                type: object
+              totalSamplesCount:
+                description: Total number of samples in the histograms.
+                type: integer
+              version:
+                description: Version of the format of the stored data.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: false
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    api-approved.kubernetes.io: https://github.com/kubernetes/kubernetes/pull/63797
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: verticalpodautoscalers.autoscaling.k8s.io
+spec:
+  group: autoscaling.k8s.io
+  names:
+    kind: VerticalPodAutoscaler
+    listKind: VerticalPodAutoscalerList
+    plural: verticalpodautoscalers
+    shortNames:
+    - vpa
+    singular: verticalpodautoscaler
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .spec.updatePolicy.updateMode
+      name: Mode
+      type: string
+    - jsonPath: .status.recommendation.containerRecommendations[0].target.cpu
+      name: CPU
+      type: string
+    - jsonPath: .status.recommendation.containerRecommendations[0].target.memory
+      name: Mem
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='RecommendationProvided')].status
+      name: Provided
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1
+    schema:
+      openAPIV3Schema:
+        description: VerticalPodAutoscaler is the configuration for a vertical pod
+          autoscaler, which automatically manages pod resources based on historical
+          and real time resource utilization.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the behavior of the autoscaler. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.'
+            properties:
+              recommenders:
+                description: Recommender responsible for generating recommendation
+                  for this object. List should be empty (then the default recommender
+                  will generate the recommendation) or contain exactly one recommender.
+                items:
+                  description: VerticalPodAutoscalerRecommenderSelector points to
+                    a specific Vertical Pod Autoscaler recommender. In the future
+                    it might pass parameters to the recommender.
+                  properties:
+                    name:
+                      description: Name of the recommender responsible for generating
+                        recommendation for this object.
+                      type: string
+                  required:
+                  - name
+                  type: object
+                type: array
+              resourcePolicy:
+                description: Controls how the autoscaler computes recommended resources.
+                  The resource policy may be used to set constraints on the recommendations
+                  for individual containers. If any individual containers need to
+                  be excluded from getting the VPA recommendations, then it must be
+                  disabled explicitly by setting mode to "Off" under containerPolicies.
+                  If not specified, the autoscaler computes recommended resources
+                  for all containers in the pod, without additional constraints.
+                properties:
+                  containerPolicies:
+                    description: Per-container resource policies.
+                    items:
+                      description: ContainerResourcePolicy controls how autoscaler
+                        computes the recommended resources for a specific container.
+                      properties:
+                        containerName:
+                          description: Name of the container or DefaultContainerResourcePolicy,
+                            in which case the policy is used by the containers that
+                            don't have their own policy specified.
+                          type: string
+                        controlledResources:
+                          description: Specifies the type of recommendations that
+                            will be computed (and possibly applied) by VPA. If not
+                            specified, the default of [ResourceCPU, ResourceMemory]
+                            will be used.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                        controlledValues:
+                          description: Specifies which resource values should be controlled.
+                            The default is "RequestsAndLimits".
+                          enum:
+                          - RequestsAndLimits
+                          - RequestsOnly
+                          type: string
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the maximum amount of resources that
+                            will be recommended for the container. The default is
+                            no maximum.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the minimal amount of resources that
+                            will be recommended for the container. The default is
+                            no minimum.
+                          type: object
+                        mode:
+                          description: Whether autoscaler is enabled for the container.
+                            The default is "Auto".
+                          enum:
+                          - Auto
+                          - "Off"
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: TargetRef points to the controller managing the set of
+                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
+                  VerticalPodAutoscaler can be targeted at controller implementing
+                  scale subresource (the pod set is retrieved from the controller's
+                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
+                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
+                  cannot use specified target it will report ConfigUnsupported condition.
+                  Note that VerticalPodAutoscaler does not require full implementation
+                  of scale subresource - it will not use it to modify the replica
+                  count. The only thing retrieved is a label selector matching pods
+                  grouped by the target resource.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              updatePolicy:
+                description: Describes the rules on how changes are applied to the
+                  pods. If not specified, all fields in the `PodUpdatePolicy` are
+                  set to their default values.
+                properties:
+                  evictionRequirements:
+                    description: EvictionRequirements is a list of EvictionRequirements
+                      that need to evaluate to true in order for a Pod to be evicted.
+                      If more than one EvictionRequirement is specified, all of them
+                      need to be fulfilled to allow eviction.
+                    items:
+                      description: EvictionRequirement defines a single condition
+                        which needs to be true in order to evict a Pod
+                      properties:
+                        changeRequirement:
+                          description: EvictionChangeRequirement refers to the relationship
+                            between the new target recommendation for a Pod and its
+                            current requests, what kind of change is necessary for
+                            the Pod to be evicted
+                          enum:
+                          - TargetHigherThanRequests
+                          - TargetLowerThanRequests
+                          type: string
+                        resources:
+                          description: Resources is a list of one or more resources
+                            that the condition applies to. If more than one resource
+                            is given, the EvictionRequirement is fulfilled if at least
+                            one resource meets `changeRequirement`.
+                          items:
+                            description: ResourceName is the name identifying various
+                              resources in a ResourceList.
+                            type: string
+                          type: array
+                      required:
+                      - changeRequirement
+                      - resources
+                      type: object
+                    type: array
+                  minReplicas:
+                    description: Minimal number of replicas which need to be alive
+                      for Updater to attempt pod eviction (pending other checks like
+                      PDB). Only positive values are allowed. Overrides global '--min-replicas'
+                      flag.
+                    format: int32
+                    type: integer
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the pod
+                      resources. The default is 'Auto'.
+                    enum:
+                    - "Off"
+                    - Initial
+                    - Recreate
+                    - Auto
+                    type: string
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Current information about the autoscaler.
+            properties:
+              conditions:
+                description: Conditions is the set of conditions required for this
+                  autoscaler to scale its target, and indicates whether or not those
+                  conditions are met.
+                items:
+                  description: VerticalPodAutoscalerCondition describes the state
+                    of a VerticalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              recommendation:
+                description: The most recently computed amount of resources recommended
+                  by the autoscaler for the controlled pods.
+                properties:
+                  containerRecommendations:
+                    description: Resources recommended by the autoscaler for each
+                      container.
+                    items:
+                      description: RecommendedContainerResources is the recommendation
+                        of resources computed by autoscaler for a specific container.
+                        Respects the container resource policy if present in the spec.
+                        In particular the recommendation is not produced for containers
+                        with `ContainerScalingMode` set to 'Off'.
+                      properties:
+                        containerName:
+                          description: Name of the container.
+                          type: string
+                        lowerBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Minimum recommended amount of resources. Observes
+                            ContainerResourcePolicy. This amount is not guaranteed
+                            to be sufficient for the application to operate in a stable
+                            way, however running with less resources is likely to
+                            have significant impact on performance/availability.
+                          type: object
+                        target:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          type: object
+                        uncappedTarget:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: The most recent recommended resources target
+                            computed by the autoscaler for the controlled pods, based
+                            only on actual resource usage, not taking into account
+                            the ContainerResourcePolicy. May differ from the Recommendation
+                            if the actual resource usage causes the target to violate
+                            the ContainerResourcePolicy (lower than MinAllowed or
+                            higher that MaxAllowed). Used only as status indication,
+                            will not affect actual resource assignment.
+                          type: object
+                        upperBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Maximum recommended amount of resources. Observes
+                            ContainerResourcePolicy. Any resources allocated beyond
+                            this value are likely wasted. This value may be larger
+                            than the maximum amount of application is actually capable
+                            of consuming.
+                          type: object
+                      required:
+                      - target
+                      type: object
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}
+  - deprecated: true
+    deprecationWarning: autoscaling.k8s.io/v1beta2 API is deprecated
+    name: v1beta2
+    schema:
+      openAPIV3Schema:
+        description: VerticalPodAutoscaler is the configuration for a vertical pod
+          autoscaler, which automatically manages pod resources based on historical
+          and real time resource utilization.
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: 'Specification of the behavior of the autoscaler. More info:
+              https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#spec-and-status.'
+            properties:
+              resourcePolicy:
+                description: Controls how the autoscaler computes recommended resources.
+                  The resource policy may be used to set constraints on the recommendations
+                  for individual containers. If not specified, the autoscaler computes
+                  recommended resources for all containers in the pod, without additional
+                  constraints.
+                properties:
+                  containerPolicies:
+                    description: Per-container resource policies.
+                    items:
+                      description: ContainerResourcePolicy controls how autoscaler
+                        computes the recommended resources for a specific container.
+                      properties:
+                        containerName:
+                          description: Name of the container or DefaultContainerResourcePolicy,
+                            in which case the policy is used by the containers that
+                            don't have their own policy specified.
+                          type: string
+                        maxAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the maximum amount of resources that
+                            will be recommended for the container. The default is
+                            no maximum.
+                          type: object
+                        minAllowed:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Specifies the minimal amount of resources that
+                            will be recommended for the container. The default is
+                            no minimum.
+                          type: object
+                        mode:
+                          description: Whether autoscaler is enabled for the container.
+                            The default is "Auto".
+                          enum:
+                          - Auto
+                          - "Off"
+                          type: string
+                      type: object
+                    type: array
+                type: object
+              targetRef:
+                description: TargetRef points to the controller managing the set of
+                  pods for the autoscaler to control - e.g. Deployment, StatefulSet.
+                  VerticalPodAutoscaler can be targeted at controller implementing
+                  scale subresource (the pod set is retrieved from the controller's
+                  ScaleStatus) or some well known controllers (e.g. for DaemonSet
+                  the pod set is read from the controller's spec). If VerticalPodAutoscaler
+                  cannot use specified target it will report ConfigUnsupported condition.
+                  Note that VerticalPodAutoscaler does not require full implementation
+                  of scale subresource - it will not use it to modify the replica
+                  count. The only thing retrieved is a label selector matching pods
+                  grouped by the target resource.
+                properties:
+                  apiVersion:
+                    description: API version of the referent
+                    type: string
+                  kind:
+                    description: 'Kind of the referent; More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent; More info: http://kubernetes.io/docs/user-guide/identifiers#names'
+                    type: string
+                required:
+                - kind
+                - name
+                type: object
+                x-kubernetes-map-type: atomic
+              updatePolicy:
+                description: Describes the rules on how changes are applied to the
+                  pods. If not specified, all fields in the `PodUpdatePolicy` are
+                  set to their default values.
+                properties:
+                  updateMode:
+                    description: Controls when autoscaler applies changes to the pod
+                      resources. The default is 'Auto'.
+                    enum:
+                    - "Off"
+                    - Initial
+                    - Recreate
+                    - Auto
+                    type: string
+                type: object
+            required:
+            - targetRef
+            type: object
+          status:
+            description: Current information about the autoscaler.
+            properties:
+              conditions:
+                description: Conditions is the set of conditions required for this
+                  autoscaler to scale its target, and indicates whether or not those
+                  conditions are met.
+                items:
+                  description: VerticalPodAutoscalerCondition describes the state
+                    of a VerticalPodAutoscaler at a certain point.
+                  properties:
+                    lastTransitionTime:
+                      description: lastTransitionTime is the last time the condition
+                        transitioned from one status to another
+                      format: date-time
+                      type: string
+                    message:
+                      description: message is a human-readable explanation containing
+                        details about the transition
+                      type: string
+                    reason:
+                      description: reason is the reason for the condition's last transition.
+                      type: string
+                    status:
+                      description: status is the status of the condition (True, False,
+                        Unknown)
+                      type: string
+                    type:
+                      description: type describes the current condition
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              recommendation:
+                description: The most recently computed amount of resources recommended
+                  by the autoscaler for the controlled pods.
+                properties:
+                  containerRecommendations:
+                    description: Resources recommended by the autoscaler for each
+                      container.
+                    items:
+                      description: RecommendedContainerResources is the recommendation
+                        of resources computed by autoscaler for a specific container.
+                        Respects the container resource policy if present in the spec.
+                        In particular the recommendation is not produced for containers
+                        with `ContainerScalingMode` set to 'Off'.
+                      properties:
+                        containerName:
+                          description: Name of the container.
+                          type: string
+                        lowerBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Minimum recommended amount of resources. Observes
+                            ContainerResourcePolicy. This amount is not guaranteed
+                            to be sufficient for the application to operate in a stable
+                            way, however running with less resources is likely to
+                            have significant impact on performance/availability.
+                          type: object
+                        target:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Recommended amount of resources. Observes ContainerResourcePolicy.
+                          type: object
+                        uncappedTarget:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: The most recent recommended resources target
+                            computed by the autoscaler for the controlled pods, based
+                            only on actual resource usage, not taking into account
+                            the ContainerResourcePolicy. May differ from the Recommendation
+                            if the actual resource usage causes the target to violate
+                            the ContainerResourcePolicy (lower than MinAllowed or
+                            higher that MaxAllowed). Used only as status indication,
+                            will not affect actual resource assignment.
+                          type: object
+                        upperBound:
+                          additionalProperties:
+                            anyOf:
+                            - type: integer
+                            - type: string
+                            pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                            x-kubernetes-int-or-string: true
+                          description: Maximum recommended amount of resources. Observes
+                            ContainerResourcePolicy. Any resources allocated beyond
+                            this value are likely wasted. This value may be larger
+                            than the maximum amount of application is actually capable
+                            of consuming.
+                          type: object
+                      required:
+                      - target
+                      type: object
+                    type: array
+                type: object
+            type: object
+        required:
+        - spec
+        type: object
+    served: true
+    storage: false
+    subresources:
+      status: {}

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -69,9 +69,7 @@ var _ = Describe("Oidc Apps Deployment Framework Test", Ordered, func() {
 				Port:    env.WebhookInstallOptions.LocalServingPort,
 				Host:    env.WebhookInstallOptions.LocalServingHost,
 				CertDir: env.WebhookInstallOptions.LocalServingCertDir,
-				TLSOpts: []func(*tls.Config){func(config *tls.Config) {
-					config.InsecureSkipVerify = false // to delete later
-				}},
+				TLSOpts: []func(*tls.Config){func(config *tls.Config) {}},
 			}),
 		})
 		Expect(err).NotTo(HaveOccurred())
@@ -116,6 +114,7 @@ var _ = Describe("Oidc Apps Deployment Framework Test", Ordered, func() {
 
 		BeforeAll(func() {
 			// Create a deployment and the downstream replicaset and the pod as there is no controller to create them
+			time.Sleep(1 * time.Second)
 			deployment = createDeployment()
 			Expect(c.Create(context.TODO(), deployment)).Should(Succeed())
 

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -32,7 +32,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("Oidc Apps Deployment Framework Test", Ordered, func() {
+var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 
 	Context("when a deployment is a target", Ordered, func() {
 

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -56,12 +56,6 @@ var _ = Describe("Oidc Apps Deployment Framework Test", Ordered, func() {
 			logr.NewContext(context.Background(), _log),
 			15*time.Second,
 		)
-
-		//TODO: Clean up all debug logs
-		_log.Info("env", "LocalServingPort", env.WebhookInstallOptions.LocalServingPort)
-		_log.Info("env", "LocalServingHost", env.WebhookInstallOptions.LocalServingHost)
-		_log.Info("env", "LocalServingCertDir", env.WebhookInstallOptions.LocalServingCertDir)
-
 		// Initialize the controller-runtime manager
 		m, err = controllerruntime.NewManager(cfg, controllerruntime.Options{
 			Logger: _log,
@@ -83,19 +77,15 @@ var _ = Describe("Oidc Apps Deployment Framework Test", Ordered, func() {
 		go func() {
 			defer GinkgoRecover()
 			Expect(m.GetWebhookServer().Start(context.TODO())).Should(Succeed())
-			_log.Info("Webhook server started")
 			Expect(m.GetCache().Start(context.TODO())).Should(Succeed())
-			_log.Info("Cache started")
-		}()
 
-		_log.Info("Manager started")
+		}()
 
 		conf := &admissionv1.MutatingWebhookConfiguration{}
 		err = c.Get(context.TODO(), client.ObjectKey{
 			Namespace: "",
 			Name:      "oidc-apps-controller-pods.gardener.cloud",
 		}, conf)
-		_log.Info("Webhook configuration", "conf", conf)
 		Expect(err).ShouldNot(HaveOccurred())
 
 	})

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -77,7 +77,7 @@ func installWebHooks(env *envtest.Environment) {
 	}
 }
 
-func createDeployment() *appsv1.Deployment {
+func createTargetDeployment() *appsv1.Deployment {
 	return &appsv1.Deployment{
 		TypeMeta: metav1.TypeMeta{
 			APIVersion: "apps/v1",

--- a/test/e2e/statefulset_test.go
+++ b/test/e2e/statefulset_test.go
@@ -45,32 +45,32 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 			// Create a deployment and the downstream replicaset and the pod as there is no controller to create them
 			statefulSet = createTargetStatefulSet()
 			Eventually(func() error {
-				return c.Create(ctx, statefulSet)
+				return clt.Create(ctx, statefulSet)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 			// Target StatefulSet shall be scaled with 2 replicas
 			pod0 = createStatefulSetPod(statefulSet, "0")
 			Eventually(func() error {
-				return c.Create(ctx, pod0)
+				return clt.Create(ctx, pod0)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 			pod1 = createStatefulSetPod(statefulSet, "1")
 			Eventually(func() error {
-				return c.Create(ctx, pod1)
+				return clt.Create(ctx, pod1)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 			suffix = rand.GenerateSha256(strings.Join([]string{TARGET, DEFAULT_NAMESPACE}, "-"))
 		}, NodeTimeout(5*time.Second))
 
 		AfterAll(func(ctx SpecContext) {
-			Expect(client.IgnoreNotFound(c.Delete(ctx, statefulSet))).Should(Succeed())
-			Expect(client.IgnoreNotFound(c.Delete(ctx, pod0))).Should(Succeed())
-			Expect(client.IgnoreNotFound(c.Delete(ctx, pod1))).Should(Succeed())
+			Expect(client.IgnoreNotFound(clt.Delete(ctx, statefulSet))).Should(Succeed())
+			Expect(client.IgnoreNotFound(clt.Delete(ctx, pod0))).Should(Succeed())
+			Expect(client.IgnoreNotFound(clt.Delete(ctx, pod1))).Should(Succeed())
 			suffix = ""
 		}, NodeTimeout(5*time.Second))
 
 		It("there shall be auth & authz sidecar containers present in the statefulset pods", func() {
 			pod := &corev1.Pod{}
-			Expect(c.Get(ctx,
+			Expect(clt.Get(ctx,
 				client.ObjectKey{
 					Namespace: DEFAULT_NAMESPACE,
 					Name:      TARGET + "-0",
@@ -79,7 +79,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 
 			Expect(pod.Spec.Containers).Should(HaveLen(3))
 			pod = &corev1.Pod{}
-			Expect(c.Get(ctx,
+			Expect(clt.Get(ctx,
 				client.ObjectKey{
 					Namespace: DEFAULT_NAMESPACE,
 					Name:      TARGET + "-1",
@@ -93,7 +93,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 			ingresses := networkingv1.IngressList{}
 			By("checking the ingress for the first pod")
 			Eventually(func() error {
-				if err = c.List(ctx, &ingresses,
+				if err = clt.List(ctx, &ingresses,
 					client.InNamespace(DEFAULT_NAMESPACE),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
@@ -116,7 +116,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 
 			By("checking the ingress for the second pod")
 			Eventually(func() error {
-				if err = c.List(ctx, &ingresses,
+				if err = clt.List(ctx, &ingresses,
 					client.InNamespace(DEFAULT_NAMESPACE),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
@@ -136,7 +136,6 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 				}
 				return fmt.Errorf("An expected oidc-apps ingress: %s is not found", constants.IngressName+"-1-"+podSuffix)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
-
 		}, NodeTimeout(5*time.Second))
 
 		It("there shall be oauth2 services per pod present in the statefulset namespace", func(ctx SpecContext) {
@@ -144,7 +143,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 			services := corev1.ServiceList{}
 			By("checking the service for the first pod")
 			Eventually(func() error {
-				if err = c.List(ctx, &services,
+				if err = clt.List(ctx, &services,
 					client.InNamespace(DEFAULT_NAMESPACE),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
@@ -165,7 +164,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 
 			By("checking the service for the second pod")
 			Eventually(func() error {
-				if err = c.List(ctx, &services,
+				if err = clt.List(ctx, &services,
 					client.InNamespace(DEFAULT_NAMESPACE),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
@@ -189,7 +188,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 
 			secrets := corev1.SecretList{}
 			Eventually(func() error {
-				if err = c.List(ctx, &secrets,
+				if err = clt.List(ctx, &secrets,
 					client.InNamespace(DEFAULT_NAMESPACE),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
@@ -214,7 +213,7 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 		It("there shall be a rbac secret present in the statefulset namespace", func(ctx SpecContext) {
 			secrets := corev1.SecretList{}
 			Eventually(func() error {
-				if err = c.List(ctx, &secrets,
+				if err = clt.List(ctx, &secrets,
 					client.InNamespace(DEFAULT_NAMESPACE),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{

--- a/test/e2e/statefulset_test.go
+++ b/test/e2e/statefulset_test.go
@@ -29,7 +29,7 @@ import (
 	"time"
 )
 
-var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
+var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 
 	Context("when a statefulset is a target", Ordered, func() {
 		var (

--- a/test/e2e/statefulset_test.go
+++ b/test/e2e/statefulset_test.go
@@ -25,11 +25,6 @@ import (
 
 var _ = Describe("Oidc Apps StatefulSets Framework Test", func() {
 
-	var (
-		_      context.Context
-		cancel context.CancelFunc
-	)
-
 	// Initialize the test environment
 	BeforeEach(func() {
 		_, cancel = context.WithTimeout(
@@ -44,7 +39,6 @@ var _ = Describe("Oidc Apps StatefulSets Framework Test", func() {
 	})
 	Context("when a statefulset is a target", func() {
 		It("there shall be  auth & autz proxies present in the statefulset", func() {})
-
 		When("the statefulset is created with two pods", func() {
 			It("there shall be an ingress and service for each pod", func() {})
 		})

--- a/test/e2e/statefulset_test.go
+++ b/test/e2e/statefulset_test.go
@@ -15,43 +15,226 @@
 package e2e
 
 import (
-	"context"
-	_ "embed"
-	"time"
-
-	"github.com/go-logr/logr"
+	"fmt"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/rand"
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	networkingv1 "k8s.io/api/networking/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+	"time"
 )
 
-var _ = Describe("Oidc Apps StatefulSets Framework Test", func() {
+var _ = Describe("Oidc Apps StatefulSets Framework Test", Ordered, func() {
 
-	// Initialize the test environment
-	BeforeEach(func() {
-		_, cancel = context.WithTimeout(
-			logr.NewContext(context.Background(), _log),
-			30*time.Second,
+	Context("when a statefulset is a target", Ordered, func() {
+		var (
+			statefulSet       *appsv1.StatefulSet
+			pod0, pod1        *corev1.Pod
+			suffix, podSuffix string
 		)
 
-	})
+		// We need to implement a retryable operations in the BeforeAll block because the webhook server might not be
+		// initialized before the pod is created and the admission webhook is called. In the latter case, the pod creation
+		// will fail because the webhook server is not ready to serve the k8s-apiserver request.
+		BeforeAll(func(ctx SpecContext) {
+			// Create a deployment and the downstream replicaset and the pod as there is no controller to create them
+			statefulSet = createTargetStatefulSet()
+			Eventually(func() error {
+				return c.Create(ctx, statefulSet)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 
-	AfterEach(func() {
-		cancel()
-	})
-	Context("when a statefulset is a target", func() {
-		It("there shall be  auth & autz proxies present in the statefulset", func() {})
-		When("the statefulset is created with two pods", func() {
-			It("there shall be an ingress and service for each pod", func() {})
-		})
-		It("there shall be oauth2 and kube-rbac secrets present in the statefulset namespace", func() {})
-		When("the statefulset is scaled to 0", func() {
-			It("there shall be no ingress & services for pods present in the statefulset", func() {})
-		})
-		When("the statefulset is deleted", func() {
-			It("there shall be no auth & autz proxies present in the statefulset", func() {})
-		})
-	})
-	Context("when a statefulset is not a target", func() {
-		It("there shall be no auth & autz proxies present in the statefulset", func() {})
-	})
+			// Target StatefulSet shall be scaled with 2 replicas
+			pod0 = createStatefulSetPod(statefulSet, "0")
+			Eventually(func() error {
+				return c.Create(ctx, pod0)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+			pod1 = createStatefulSetPod(statefulSet, "1")
+			Eventually(func() error {
+				return c.Create(ctx, pod1)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 
+			suffix = rand.GenerateSha256(strings.Join([]string{TARGET, DEFAULT_NAMESPACE}, "-"))
+		}, NodeTimeout(5*time.Second))
+
+		AfterAll(func(ctx SpecContext) {
+			Expect(client.IgnoreNotFound(c.Delete(ctx, statefulSet))).Should(Succeed())
+			Expect(client.IgnoreNotFound(c.Delete(ctx, pod0))).Should(Succeed())
+			Expect(client.IgnoreNotFound(c.Delete(ctx, pod1))).Should(Succeed())
+			suffix = ""
+		}, NodeTimeout(5*time.Second))
+
+		It("there shall be auth & authz sidecar containers present in the statefulset pods", func() {
+			pod := &corev1.Pod{}
+			Expect(c.Get(ctx,
+				client.ObjectKey{
+					Namespace: DEFAULT_NAMESPACE,
+					Name:      TARGET + "-0",
+				},
+				pod)).Should(Succeed())
+
+			Expect(pod.Spec.Containers).Should(HaveLen(3))
+			pod = &corev1.Pod{}
+			Expect(c.Get(ctx,
+				client.ObjectKey{
+					Namespace: DEFAULT_NAMESPACE,
+					Name:      TARGET + "-1",
+				},
+				pod)).Should(Succeed())
+
+			Expect(pod.Spec.Containers).Should(HaveLen(3))
+		})
+
+		It("there shall be an oidc-apps ingress per pod present in the statefulset namespace", func(ctx SpecContext) {
+			ingresses := networkingv1.IngressList{}
+			By("checking the ingress for the first pod")
+			Eventually(func() error {
+				if err = c.List(ctx, &ingresses,
+					client.InNamespace(DEFAULT_NAMESPACE),
+					client.MatchingLabelsSelector{
+						Selector: labels.SelectorFromSet(map[string]string{
+							constants.LabelKey: constants.LabelValue,
+						}),
+					}); err != nil {
+					return err
+				}
+				if len(ingresses.Items) == 0 {
+					return fmt.Errorf("no oidc-apps ingresses are found")
+				}
+				for _, ingress := range ingresses.Items {
+					podSuffix = rand.GenerateSha256(TARGET + "-0-" + DEFAULT_NAMESPACE)
+					if ingress.Name == constants.IngressName+"-0-"+podSuffix {
+						return nil
+					}
+				}
+				return fmt.Errorf("An expected oidc-apps ingress: %s is not found", constants.IngressName+"-0-"+podSuffix)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+			By("checking the ingress for the second pod")
+			Eventually(func() error {
+				if err = c.List(ctx, &ingresses,
+					client.InNamespace(DEFAULT_NAMESPACE),
+					client.MatchingLabelsSelector{
+						Selector: labels.SelectorFromSet(map[string]string{
+							constants.LabelKey: constants.LabelValue,
+						}),
+					}); err != nil {
+					return err
+				}
+				if len(ingresses.Items) == 0 {
+					return fmt.Errorf("no oidc-apps ingresses are found")
+				}
+				for _, ingress := range ingresses.Items {
+					podSuffix = rand.GenerateSha256(TARGET + "-1-" + DEFAULT_NAMESPACE)
+					if ingress.Name == constants.IngressName+"-1-"+podSuffix {
+						return nil
+					}
+				}
+				return fmt.Errorf("An expected oidc-apps ingress: %s is not found", constants.IngressName+"-1-"+podSuffix)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+		}, NodeTimeout(5*time.Second))
+
+		It("there shall be oauth2 services per pod present in the statefulset namespace", func(ctx SpecContext) {
+
+			services := corev1.ServiceList{}
+			By("checking the service for the first pod")
+			Eventually(func() error {
+				if err = c.List(ctx, &services,
+					client.InNamespace(DEFAULT_NAMESPACE),
+					client.MatchingLabelsSelector{
+						Selector: labels.SelectorFromSet(map[string]string{
+							constants.LabelKey: constants.LabelValue,
+						}),
+					}); err != nil {
+					return err
+				}
+				podSuffix = rand.GenerateSha256(TARGET + "-0-" + DEFAULT_NAMESPACE)
+				for _, service := range services.Items {
+					if service.Name == constants.ServiceNameOauth2Service+"-0-"+podSuffix {
+						return nil
+					}
+				}
+				return fmt.Errorf("An expected oidc-apps service: %s is not found",
+					constants.ServiceNameOauth2Service+"-0-"+podSuffix)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+
+			By("checking the service for the second pod")
+			Eventually(func() error {
+				if err = c.List(ctx, &services,
+					client.InNamespace(DEFAULT_NAMESPACE),
+					client.MatchingLabelsSelector{
+						Selector: labels.SelectorFromSet(map[string]string{
+							constants.LabelKey: constants.LabelValue,
+						}),
+					}); err != nil {
+					return err
+				}
+				podSuffix = rand.GenerateSha256(TARGET + "-1-" + DEFAULT_NAMESPACE)
+				for _, service := range services.Items {
+					if service.Name == constants.ServiceNameOauth2Service+"-1-"+podSuffix {
+						return nil
+					}
+				}
+				return fmt.Errorf("An expected oidc-apps service: %s is not found",
+					constants.ServiceNameOauth2Service+"-0-"+podSuffix)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+		}, NodeTimeout(5*time.Second))
+
+		It("there shall be an oauth2 secret present in the statefulset namespace", func(ctx SpecContext) {
+
+			secrets := corev1.SecretList{}
+			Eventually(func() error {
+				if err = c.List(ctx, &secrets,
+					client.InNamespace(DEFAULT_NAMESPACE),
+					client.MatchingLabelsSelector{
+						Selector: labels.SelectorFromSet(map[string]string{
+							constants.SecretLabelKey: constants.Oauth2LabelValue,
+						}),
+					}); err != nil {
+					return err
+				}
+				if len(secrets.Items) == 0 {
+					return fmt.Errorf("no oidc-apps secrets are found")
+				}
+				for _, secret := range secrets.Items {
+					if secret.Name == constants.SecretNameOauth2Proxy+"-"+suffix {
+						return nil
+					}
+				}
+				return fmt.Errorf("An expected oidc-apps oauth2 secret: %s is not found",
+					constants.SecretNameOauth2Proxy+"-"+suffix)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+		}, NodeTimeout(5*time.Second))
+
+		It("there shall be a rbac secret present in the statefulset namespace", func(ctx SpecContext) {
+			secrets := corev1.SecretList{}
+			Eventually(func() error {
+				if err = c.List(ctx, &secrets,
+					client.InNamespace(DEFAULT_NAMESPACE),
+					client.MatchingLabelsSelector{
+						Selector: labels.SelectorFromSet(map[string]string{
+							constants.SecretLabelKey: constants.RbacLabelValue,
+						}),
+					}); err != nil {
+					return err
+				}
+				if len(secrets.Items) == 0 {
+					return fmt.Errorf("no oidc-apps secrets are found")
+				}
+				for _, secret := range secrets.Items {
+					if secret.Name == constants.SecretNameResourceAttributes+"-"+suffix {
+						return nil
+					}
+				}
+				return fmt.Errorf("An expected oidc-apps ressource-attributes secret: %s is not found",
+					constants.SecretNameResourceAttributes+"-"+suffix)
+			}).WithPolling(100 * time.Millisecond).Should(Succeed())
+		}, NodeTimeout(5*time.Second))
+
+	})
 })


### PR DESCRIPTION
This PR brings controller-runtime webhook tests

 * envtest.Environment contains WebhookInstallOptions with pod mutating webhook

 * BeforeSuite contains logic for starting controller-runtime manager with webhook server

 * "Oidc Apps Deployment Target Test" creates a target deployment, replicaset and a pod with proper owner references  
 and validates the presence of the controller managed resources
 
* "Oidc Apps Statefulset Target Test" creates a target statefulset and a pod with proper owner references  
 and validates the presence of the controller managed resources

-->
```feature developer
With controller-runtime envtests for the oidc-apps-controller mutating webhooks
```
