### PR TITLE
Support annotations in targets ingress resources

### DIFF
--- a/example/controller-registration.yaml
+++ b/example/controller-registration.yaml
@@ -9,7 +9,7 @@ providerConfig:
   values:
     image:
       repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/oidc-apps-controller
-      tag: v0.2.18-dev
+      tag: v0.2.19-dev
     imagePullSecrets:
       - name: gardener-images
     webhook:

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -469,6 +469,15 @@ func (c *OIDCAppsControllerConfig) GetIngressClassName(object client.Object) str
 	return ""
 }
 
+// GetIngressAnnotations returns the ingress annotations for the given target
+func (c *OIDCAppsControllerConfig) GetIngressAnnotations(object client.Object) map[string]string {
+	t := c.fetchTarget(object)
+	if t.Ingress != nil && t.Ingress.Annotations != nil {
+		return t.Ingress.Annotations
+	}
+	return nil
+}
+
 func (c *OIDCAppsControllerConfig) fetchTarget(o client.Object) Target {
 
 	var targets []Target

--- a/pkg/controllers/oidc-apps-ingresses.go
+++ b/pkg/controllers/oidc-apps-ingresses.go
@@ -35,7 +35,7 @@ func createIngressForDeployment(object client.Object) (networkingv1.Ingress, err
 	ingressTLSSecretName := configuration.GetOIDCAppsControllerConfig().GetIngressTLSSecretName(object)
 	host := configuration.GetOIDCAppsControllerConfig().GetHost(object)
 
-	return networkingv1.Ingress{
+	ingress := networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.IngressName + "-" + suffix,
 			Namespace: object.GetNamespace(),
@@ -73,7 +73,13 @@ func createIngressForDeployment(object client.Object) (networkingv1.Ingress, err
 				},
 			},
 		},
-	}, nil
+	}
+
+	if annotations := configuration.GetOIDCAppsControllerConfig().GetIngressAnnotations(object); len(annotations) > 0 {
+		ingress.ObjectMeta.Annotations = annotations
+	}
+
+	return ingress, nil
 }
 
 func createIngressForStatefulSetPod(pod *corev1.Pod, object client.Object) (networkingv1.Ingress, error) {
@@ -87,7 +93,7 @@ func createIngressForStatefulSetPod(pod *corev1.Pod, object client.Object) (netw
 	host, domain, _ := strings.Cut(hostPrefix, ".")
 	index := fetchStrIndexIfPresent(pod)
 
-	return networkingv1.Ingress{
+	ingress := networkingv1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      constants.IngressName + "-" + addOptionalIndex(index+"-") + suffix,
 			Namespace: object.GetNamespace(),
@@ -126,5 +132,9 @@ func createIngressForStatefulSetPod(pod *corev1.Pod, object client.Object) (netw
 				},
 			},
 		},
-	}, nil
+	}
+	if annotations := configuration.GetOIDCAppsControllerConfig().GetIngressAnnotations(object); len(annotations) > 0 {
+		ingress.ObjectMeta.Annotations = annotations
+	}
+	return ingress, nil
 }


### PR DESCRIPTION
# What this PR does

This PR adds support for adding annotations to target ingresses.

Following example illustrates adding annotations to a grafana target, leveraging the default cert-manager and dns-manager extensions in gardener shoot clusters. Once the ingresses are annorated the respective extensions take over the lifecycle of the dns records and server-side certificates of the expose ingress.

```yaml
ingress:
  create: true
  ingressClassName: nginx
  annotations:
    cert.gardener.cloud/purpose: managed
    dns.gardener.cloud/class: garden
    dns.gardener.cloud/dnsnames: "*"
    dns.gardener.cloud/ttl: "600"
    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
  tlsSecretRef:
    name: "grafana-tls"
```

```feature user
oidc-apps-controller now supports specifying annotations for the target ingresses
```
