### PR TITLE
update dependencies

### DIFF
--- a/example/provider-local/02-check_environment.sh
+++ b/example/provider-local/02-check_environment.sh
@@ -185,7 +185,7 @@ function check_hosts {
         prometheus-seed-garden-0.ingress.local.seed.local.gardener.cloud
         prometheus-aggregate-garden-0.ingress.local.seed.local.gardener.cloud
         prometheus-cache-garden-0.ingress.local.seed.local.gardener.cloud
-        prometheus-shoot--local--local-0.ingress.local.seed.local.gardener.cloud
+        prometheus-shoot-shoot--local--local-0.ingress.local.seed.local.gardener.cloud
         plutono-shoot--local--local.ingress.local.seed.local.gardener.cloud
     )
     for record in "${records[@]}"; do

--- a/example/provider-local/configs/dex-config.yaml
+++ b/example/provider-local/configs/dex-config.yaml
@@ -63,7 +63,7 @@ staticClients:
       - "https://prometheus-seed-garden-0.ingress.local.seed.local.gardener.cloud/oauth2/callback"
       - "https://prometheus-cache-garden-0.ingress.local.seed.local.gardener.cloud/oauth2/callback"
       - "https://pr-404698-0.ingress.local.seed.local.gardener.cloud/oauth2/callback"
-      - "https://prometheus-shoot--local--local-0.ingress.local.seed.local.gardener.cloud/oauth2/callback"
+      - "https://prometheus-shoot-shoot--local--local-0.ingress.local.seed.local.gardener.cloud/oauth2/callback"
       - "https://pl-b5e187.ingress.local.seed.local.gardener.cloud/oauth2/callback"
       - "https://plutono-shoot--local--local.ingress.local.seed.local.gardener.cloud/oauth2/callback"
     name: "oauth2-proxy"

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.5"
+    tag: "v0.1.6"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -15,4 +15,4 @@ images:
   - name: "curl-container"
     sourceRepository: github.com/curl/curl-container
     repository: "quay.io/curl/curl"
-    tag: "8.10.1"
+    tag: "8.11.0"


### PR DESCRIPTION
This PR brings following dependencies updates:
- **bump up kube-rbac-proxy-watcher to 0.1.6**
- **bump up curl-container to 8.11.0**

The PR also brings a fix the example/provide-local urls.

```other developer
None
```
