### PR TITLE
Migrate "oidc-init" to sidecar container

### DIFF
--- a/pkg/webhook/modifiers.go
+++ b/pkg/webhook/modifiers.go
@@ -339,7 +339,8 @@ func getInitContainer(oidcIssuerUrl string) corev1.Container {
 				Value: oidcIssuerUrl,
 			},
 		},
-		Args: []string{oidcInitCheck},
+		Args:          []string{oidcInitCheck},
+		RestartPolicy: ptr.To(corev1.ContainerRestartPolicyAlways),
 		Resources: corev1.ResourceRequirements{
 			Limits: map[corev1.ResourceName]resource.Quantity{
 				"cpu":    resource.MustParse("10m"),

--- a/pkg/webhook/oidc-check.sh
+++ b/pkg/webhook/oidc-check.sh
@@ -4,9 +4,9 @@
 
 options="--connect-timeout 2 --max-time 10 --retry 3 --retry-delay 1"
 options="$options --cacert /etc/kube-rbac-proxy/ca.crt"
-options="$options -w \"%{http_code}\" -sS -o /dev/null"
+options="$options -sSv"
 check="curl ${options} "${OIDC_URL}/.well-known/openid-configuration""
-until  $( $check |grep -q "200" ); do
-  echo "Executing ${check} returns non-200 response, retrying..."
-  sleep 1
+while true; do
+  $check || true
+  sleep 120
 done


### PR DESCRIPTION
This PR migrates `oidc-init` container from classic init-container to sidecar container [k8s 1.29].
The purpose is to have a mechanism to ping upstream `oidc-provider` without interruption of the main application containers.


```other operator
The oidc-init will not interfere with start-up of the main application containers in the pod
```
