### PR TITLE
cleanup: drop unused codepath

### DIFF
--- a/hack/.ci/component_descriptor
+++ b/hack/.ci/component_descriptor
@@ -71,27 +71,4 @@ if [[ ! -z "$image_vector_path" ]]; then
   component-cli image-vector add ${COMPONENT_CLI_ARGS}
 fi
 
-if [[ -d "$repo_root_dir/charts/" ]]; then
-  for image_tpl_path in "$repo_root_dir/charts/"*"/templates/_images.tpl"; do
-    if [[ ! -f "$image_tpl_path" ]]; then
-      continue
-    fi
-
-    outputFile=$(sed 's/{{-//' $image_tpl_path | sed 's/}}//' | sed 's/define//' | sed 's/-//' | sed 's/end//' | sed 's/"//' | sed 's/"//' |sed 's/image.//' |  sed -e 's/^[ \t]*//' | awk -v RS= '{for (i=1; i<=NF; i++) printf "%s%s", $i, (i==NF?"\n":" ")}')
-    echo "enriching component descriptor from ${image_tpl_path}"
-
-    while read p; do
-      line="$(echo -e "$p")"
-      IFS=' ' read -r -a array <<< "$line"
-      IFS=': ' read -r -a imageAndTag <<< ${array[1]}
-
-      NAME=${array[0]}
-      REPOSITORY=${imageAndTag[0]}
-      TAG=${imageAndTag[1]}
-
-      ${ADD_DEPENDENCIES_CMD} --container-image-dependencies "{\"name\": \"${NAME}\", \"image_reference\": \"${REPOSITORY}:${TAG}\", \"version\": \"$TAG\"}"
-    done < <(echo "$outputFile")
-  done
-fi
-
 cp "${BASE_DEFINITION_PATH}" "${descriptor_out_file}"


### PR DESCRIPTION
`.ci/component_descriptor` was copied into this repository from https://github.com/gardener/gardener.

Historically, the file used to be vendored into muliple repositories and thus needed to support
different repository-layouts. This is no longer the case, as vendoring was dropped some time back.

Rm unused codepath as cleanup (will help migrating from Concourse-Pipeline-Template).

**How to categorize this PR?**
/area delivery
/kind cleanup


**Release note**:
<!--
Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|noteworthy|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
drop unused codepath from component_descriptor creation script.
```