### PR TITLE
Update upstream container dependencies

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -11,4 +11,4 @@ images:
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: "v7.7.1"
+    tag: "v7.8.1"

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -12,7 +12,3 @@ images:
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
     tag: "v7.7.1"
-  - name: "curl-container"
-    sourceRepository: github.com/curl/curl-container
-    repository: "quay.io/curl/curl"
-    tag: "8.11.0"

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.6"
+    tag: "v0.1.7"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy


### PR DESCRIPTION
This PR updates container image dependencies:
- kube-rbac-proxy-watcher to v0.1.7
- oauth2-proxy to v7.8.1

```feature operator
Update sidecar containers oauth2-proxy to v7.8.1, kube-rbac-proxy-watcher to v0.1.7
```
