### PR TITLE
build: bump up golang to 1.23.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go app
-FROM golang:1.23.4 AS builder
+FROM golang:1.23.5 AS builder
 
 # Set up the working directory
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gardener/oidc-apps-controller
 
-go 1.23.4
+go 1.23.5
 
 require (
 	github.com/gardener/gardener v1.92.1


### PR DESCRIPTION
This PR updates go dependency to 1.23.5

```feature developer
Update go to v1.23.5
```
