### PR TITLE
Set unprivileged  security context

### DIFF
--- a/example/provider-local/03-setup-controller.sh
+++ b/example/provider-local/03-setup-controller.sh
@@ -41,6 +41,12 @@ providerConfig:
       repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/$controller_name
       tag: $version
     imagePullPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
     cacheSelectorStr: "observability.gardener.cloud/app in (plutono, prometheus-shoot, prometheus-cache, prometheus-aggregate, prometheus-seed)"
     webhook:
       objectSelector:

--- a/example/provider-local/oidc-apps-controller-registration.yaml
+++ b/example/provider-local/oidc-apps-controller-registration.yaml
@@ -15,8 +15,14 @@ providerConfig:
         clientId: local
     image:
       repository: europe-docker.pkg.dev/gardener-project/snapshots/gardener/extensions/oidc-apps-controller
-      tag: v0.6.0-dev
+      tag: latest
     imagePullPolicy: Always
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop:
+          - ALL
+      readOnlyRootFilesystem: true
     cacheSelectorStr: "observability.gardener.cloud/app in (plutono, prometheus-shoot, prometheus-cache, prometheus-aggregate, prometheus-seed)"
     webhook:
       objectSelector:

--- a/pkg/webhook/modifiers.go
+++ b/pkg/webhook/modifiers.go
@@ -382,6 +382,11 @@ func getKubeRbacProxyContainer(clientID, issuerUrl, upstream string, pod *corev1
 		Ports: []corev1.ContainerPort{
 			{Name: "rbac", ContainerPort: 8100},
 		},
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+		},
 		Resources:    containerResourceRequirements,
 		VolumeMounts: volumeMounts,
 	}
@@ -457,6 +462,11 @@ func getOIDCProxyContainer(pod *corev1.PodSpec, owner client.Object) corev1.Cont
 			"--skip-provider-button=true",
 			"--skip-jwt-bearer-tokens=true",
 			"--upstream=http://127.0.0.1:8100"},
+		SecurityContext: &corev1.SecurityContext{
+			Capabilities:             &corev1.Capabilities{Drop: []corev1.Capability{"ALL"}},
+			AllowPrivilegeEscalation: ptr.To(false),
+			ReadOnlyRootFilesystem:   ptr.To(true),
+		},
 		Ports: []corev1.ContainerPort{
 			{Name: "oauth2", ContainerPort: 8000},
 		},


### PR DESCRIPTION
This PR sets unprivileged security context to controller and proxy containers. 

```feature developer
The controller container of "oidc-apps" and the managed proxy containers now run with an unprivileged security context.
```
