### PR TITLE
Remove VPA for sidecar containers

### DIFF
--- a/pkg/webhook/test/vpa-mutating-webhook_test.go
+++ b/pkg/webhook/test/vpa-mutating-webhook_test.go
@@ -137,31 +137,17 @@ func initNonTargetVPA() {
 
 var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 	Context("when the reconciled target has vpa", func() {
-		It("It shall contains allowMin for auth & autz proxies", func() {
+		It("It shall contain mode=Off for auth & autz proxies", func() {
 			patchedVpa := patchVpa(targetVPA)
 			_log.Info("patched pod", "patched vpa", patchedVpa)
 			Expect(patchedVpa.Spec.ResourcePolicy.ContainerPolicies).To(HaveLen(3))
 			Expect(patchedVpa.Spec.ResourcePolicy.ContainerPolicies).To(ContainElement(autoscalerv1.ContainerResourcePolicy{
 				ContainerName: constants.ContainerNameOauth2Proxy,
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				MaxAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
-				},
+				Mode:          ptr.To(autoscalerv1.ContainerScalingModeOff),
 			}))
 			Expect(patchedVpa.Spec.ResourcePolicy.ContainerPolicies).To(ContainElement(autoscalerv1.ContainerResourcePolicy{
 				ContainerName: constants.ContainerNameKubeRbacProxy,
-				MinAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("5m"),
-					corev1.ResourceMemory: resource.MustParse("32Mi"),
-				},
-				MaxAllowed: corev1.ResourceList{
-					corev1.ResourceCPU:    resource.MustParse("100m"),
-					corev1.ResourceMemory: resource.MustParse("100Mi"),
-				},
+				Mode:          ptr.To(autoscalerv1.ContainerScalingModeOff),
 			}))
 
 		})

--- a/pkg/webhook/vpa-webhook.go
+++ b/pkg/webhook/vpa-webhook.go
@@ -21,10 +21,9 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv1 "k8s.io/api/autoscaling/v1"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/json"
 	autoscalerv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
@@ -84,25 +83,11 @@ func (v *VPAMutator) Handle(ctx context.Context, req webhook.AdmissionRequest) w
 	}
 	policies = append(policies, autoscalerv1.ContainerResourcePolicy{
 		ContainerName: constants.ContainerNameOauth2Proxy,
-		MinAllowed: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-		},
-		MaxAllowed: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("100Mi"),
-		},
+		Mode:          ptr.To(autoscalerv1.ContainerScalingModeOff),
 	})
 	policies = append(policies, autoscalerv1.ContainerResourcePolicy{
 		ContainerName: constants.ContainerNameKubeRbacProxy,
-		MinAllowed: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("5m"),
-			corev1.ResourceMemory: resource.MustParse("32Mi"),
-		},
-		MaxAllowed: corev1.ResourceList{
-			corev1.ResourceCPU:    resource.MustParse("100m"),
-			corev1.ResourceMemory: resource.MustParse("100Mi"),
-		},
+		Mode:          ptr.To(autoscalerv1.ContainerScalingModeOff),
 	})
 
 	patch.Spec.ResourcePolicy.ContainerPolicies = policies


### PR DESCRIPTION
**What this PR does / why we need it**:
See https://github.com/gardener/gardener/pull/11366/files#r1953926916

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
N/A

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other operator
The `oauth2-proxy` and `kube-rbac-proxy` sidecars do no longer enable VPA as they do not benefit from it. Currently, VPA is only causing unnecessary evictions to the target StatefulSet/Deployment to apply resource recommendations for the  `oauth2-proxy` and `kube-rbac-proxy` sidecars.
```
