### PR TITLE
chore(deps): bump up kube-rbac-proxy-watcher to 0.1.9

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.8"
+    tag: "v0.1.9"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy


### PR DESCRIPTION
This PR brings latest released version of kube-rbac-proxy-watcher sidecar.

```feature user
None
```
