### PR TITLE
chore(ci): bump up verify image to golang:1.24.1

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -20,7 +20,7 @@ oidc-apps-controller:
             We use gosec for sast scanning, see attached log.
     steps:
       verify:
-        image: 'golang:1.24.0'
+        image: 'golang:1.24.1'
     traits:
       version:
         preprocess: "inject-commit-hash"


### PR DESCRIPTION
This PR updates `verify` image in CI pipeline to golang1.24.1
