### PR TITLE
chore(ci): simplify unit-test githubaction

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -11,13 +11,7 @@ on:
 
 jobs:
   test:
-    name: ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
+    runs-on: ubuntu-latest
     # Pull requests from the same repository won't trigger this checks as they were already triggered by the push
     if: (github.event_name == 'push' || github.event.pull_request.head.repo.full_name != github.repository)
     steps:
@@ -26,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: '~1.23'
+          go-version-file: 'go.mod'
       - name: Perform the unit tests
         run: make test
       - name: Perform e2e tests
@@ -36,7 +30,7 @@ jobs:
         # Only report failures of pushes (PRs are visible through the Checks section) to the default branch
         if: failure() && github.event_name == 'push' && github.ref == 'refs/heads/main'
         with:
-          title: 🐛 Unit tests failed on ${{ matrix.os }} for ${{ github.sha }}
+          title: 🐛 Unit tests failed for ${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           labels: kind/bug
           body: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
This PR simplifies the `unit-test` GitHub-action workflow.

- Removes unnecessary os matrix
- Uses go version from go.mod