### PR TITLE
Forbid container privilege escalations for the component containers

### DIFF
--- a/charts/oidc-apps-controller/values.yaml
+++ b/charts/oidc-apps-controller/values.yaml
@@ -42,7 +42,8 @@ podAnnotations: {}
 podSecurityContext: {}
 # fsGroup: 2000
 
-securityContext: {}
+securityContext:
+  allowPrivilegeEscalation: false
 # capabilities:
 #   drop:
 #   - ALL


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR sets `securityContext.allowPrivilegeEscalation` to `false` for every component container, which does not have `securityContext.Privileged` set to true or one of `CAP_SYS_ADMIN/SYS_ADMIN` capabilities added.

**Which issue(s) this PR fixes**:
Part of gardener/gardener#11139

**Special notes for your reviewer**:
cc @AleksandarSavchev 

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Controller component containers, which do not require privilege escalations, now forbid privilege escalation explicitly.
```
