### PR TITLE
Update ci verify image

### DIFF
--- a/.ci/pipeline_definitions
+++ b/.ci/pipeline_definitions
@@ -1,5 +1,5 @@
 oidc-apps-controller:
-  templates: 
+  templates:
     helmcharts:
     - &oidc-apps-controller
       name: oidc-apps-controller
@@ -20,7 +20,7 @@ oidc-apps-controller:
             We use gosec for sast scanning, see attached log.
     steps:
       verify:
-        image: 'golang:1.24.1'
+        image: 'golang:1.24.2'
     traits:
       version:
         preprocess: "inject-commit-hash"


### PR DESCRIPTION
This PR updates CI verify image to golang:1.24.2.