### PR TITLE
Update go to 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: Build the Go app
-FROM golang:1.24.1 AS builder
+FROM golang:1.24.2 AS builder
 
 # Set up the working directory
 WORKDIR /src

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/gardener/oidc-apps-controller
 
-go 1.24.1
+go 1.24.2
+
 tool (
 	github.com/golangci/golangci-lint/cmd/golangci-lint
 	github.com/google/addlicense


### PR DESCRIPTION
This PR brings go 1.24.2 to `oidc-apps-controller`

```feature developer
Update `go` to 1.24.2
```
