### PR TITLE
Update sidecars containers

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,8 +7,8 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.9"
+    tag: "v0.1.10"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: "v7.8.1"
+    tag: "v7.8.2"


### PR DESCRIPTION
This PR brings updates to proxy sidecars.

- `oauth2-proxy` container is updated to [v7.8.2](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.8.2)
- `kube-rbac-proxy-watcher` is updated to [v0.1.10](https://github.com/gardener/kube-rbac-proxy-watcher/releases/tag/v0.1.10)


```feat other developer
Proxy containers are updated:`oauth2-proxy` is updated to v7.8.2, `kube-rbac-proxy-watcher` is updated to v0.1.10
```
