### PR TITLE
Update linter configuration

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,7 +5,7 @@ run:
   go: "1.24"
 
 linters:
-  defaults: none
+  default: none
   enable:
     - errcheck
     - gocritic
@@ -16,25 +16,11 @@ linters:
     - unused
     - whitespace
     - wsl
-  exclusions:
-    generated: lax
-    rules:
-      - path: (.+)\.go$
-        text: var-naming
-      - path: (.+)\.go$
-        text: dot-imports
-      - path: (.+)\.go$
-        text: package-comments
-      - path: (.+)\.go$
-        text: indent-error-flow
-      - path: (.+)\.go$
-        text: unexported-return
-      - path: (.+)\.go$
-        text: 'exported: (type|func) name will be used as .* by other packages, and that stutters;'
-      - path: (.+)\.go$
-        text: 'undeclared name: `.*`'
-      - path: (.+)\.go$
-        text: '".*" imported but not used'
+  settings:
+    revive: # default set https://github.com/mgechev/revive/blob/master/defaults.toml
+      rules:
+        - name: dot-imports
+          disabled: true
 
 formatters:
   enable:

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -25,14 +25,14 @@ import (
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
-	oidc_apps_controller "github.com/gardener/oidc-apps-controller/pkg/oidc-apps-controller"
+	oidcappscontroller "github.com/gardener/oidc-apps-controller/pkg/oidc-apps-controller"
 )
 
 var _log = logf.Log
 
 // NewOidcAppsController returns the root command
 func NewOidcAppsController() *cobra.Command {
-	opts := &oidc_apps_controller.OidcAppsControllerOptions{}
+	opts := &oidcappscontroller.Options{}
 	fromFlags := &zap.Options{}
 
 	cmd := &cobra.Command{
@@ -53,7 +53,7 @@ func NewOidcAppsController() *cobra.Command {
 				_log.Info(fmt.Sprintf("FLAG: --%s=%s", flag.Name, flag.Value))
 			})
 
-			return oidc_apps_controller.RunController(cmd.Context(), opts)
+			return oidcappscontroller.RunController(cmd.Context(), opts)
 		},
 	}
 

--- a/pkg/certificates/generate_test.go
+++ b/pkg/certificates/generate_test.go
@@ -23,7 +23,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	gomock "go.uber.org/mock/gomock"
+	"go.uber.org/mock/gomock"
 )
 
 var tmp string

--- a/pkg/certificates/operations.go
+++ b/pkg/certificates/operations.go
@@ -24,7 +24,7 @@ import (
 // mocking dependencies in tests
 type CertificateOperations interface {
 	GenerateKey(keyLength int) (*rsa.PrivateKey, error)
-	CreateCertificate(template, parent *x509.Certificate, pub interface{}, priv interface{}) (*x509.Certificate, error)
+	CreateCertificate(template, parent *x509.Certificate, pub any, priv any) (*x509.Certificate, error)
 }
 
 type realCertOps struct{}
@@ -33,7 +33,7 @@ func (realCertOps) GenerateKey(keyLength int) (*rsa.PrivateKey, error) {
 	return rsa.GenerateKey(rand.Reader, keyLength)
 }
 
-func (realCertOps) CreateCertificate(template, parent *x509.Certificate, pub interface{}, priv interface{}) (*x509.Certificate, error) {
+func (realCertOps) CreateCertificate(template, parent *x509.Certificate, pub any, priv any) (*x509.Certificate, error) {
 	var (
 		certBytes []byte
 		err       error

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -143,8 +143,8 @@ func TestTargetGlobalConfiguration(t *testing.T) {
 	g.Expect(extensionConfig.GetClientID(target)).To(Equal("client-id"))
 	g.Expect(extensionConfig.GetScope(target)).To(Equal("openid email"))
 	g.Expect(extensionConfig.GetClientSecret(target)).To(Equal("client-secret"))
-	g.Expect(extensionConfig.GetRedirectUrl(target)).To(Equal("https://test-04-test.domain.org/oauth2/callback"))
-	g.Expect(extensionConfig.GetOidcIssuerUrl(target)).To(Equal("https://oidc-provider.org"))
+	g.Expect(extensionConfig.GetRedirectURL(target)).To(Equal("https://test-04-test.domain.org/oauth2/callback"))
+	g.Expect(extensionConfig.GetOidcIssuerURL(target)).To(Equal("https://oidc-provider.org"))
 	g.Expect(extensionConfig.GetSslInsecureSkipVerify(target)).To(BeFalse())
 	g.Expect(extensionConfig.GetInsecureOidcSkipIssuerVerification(target)).To(BeFalse())
 	g.Expect(extensionConfig.GetInsecureOidcSkipNonce(target)).To(BeFalse())
@@ -168,8 +168,8 @@ func TestTargetConfiguration(t *testing.T) {
 	g.Expect(extensionConfig.GetClientID(target)).To(Equal("client-id-target"))
 	g.Expect(extensionConfig.GetScope(target)).To(Equal("openid email target"))
 	g.Expect(extensionConfig.GetClientSecret(target)).To(Equal("client-secret-target"))
-	g.Expect(extensionConfig.GetRedirectUrl(target)).To(Equal("https://app.org/oauth2/callback"))
-	g.Expect(extensionConfig.GetOidcIssuerUrl(target)).To(Equal("https://oidc-provider-target.org"))
+	g.Expect(extensionConfig.GetRedirectURL(target)).To(Equal("https://app.org/oauth2/callback"))
+	g.Expect(extensionConfig.GetOidcIssuerURL(target)).To(Equal("https://oidc-provider-target.org"))
 	g.Expect(extensionConfig.GetOidcCASecretName(target)).To(Equal("target-oidc-ca"))
 	g.Expect(extensionConfig.GetSslInsecureSkipVerify(target)).To(BeTrue())
 	g.Expect(extensionConfig.GetInsecureOidcSkipIssuerVerification(target)).To(BeTrue())
@@ -200,8 +200,8 @@ func TestGardenConfig(t *testing.T) {
 	host := extensionConfig.GetHost(target)
 	g.Expect(host).To(Equal("test-02-prefix-4396f8.seed.domain.org"))
 
-	clientId := extensionConfig.GetClientID(target)
-	g.Expect(clientId).To(Equal("seed-client-id"))
+	clientID := extensionConfig.GetClientID(target)
+	g.Expect(clientID).To(Equal("seed-client-id"))
 }
 
 func getDeployment(name string) *appsv1.Deployment {

--- a/pkg/configuration/oauth2-proxy-template.go
+++ b/pkg/configuration/oauth2-proxy-template.go
@@ -28,15 +28,16 @@ type configParser interface {
 	Parse() string
 }
 
-type optOauth2 func(*oauth2Config)
+// OptOauth2 is a function that modifies the oauth2Config
+type OptOauth2 func(*oauth2Config)
 
 type oauth2Config struct {
 	clientID                           string
 	clientSecretFile                   string
 	clientSecret                       string
 	scope                              string
-	redirectUrl                        string
-	oidcIssuerUrl                      string
+	redirectURL                        string
+	oidcIssuerURL                      string
 	sslInsecureSkipVerify              bool
 	insecureOidcSkipIssuerVerification bool
 	insecureOidcSkipNonce              bool
@@ -76,9 +77,9 @@ func (o *oauth2Config) Parse() string {
 						line = ""
 					}
 				case "redirect_url":
-					line = l + "=" + "\"" + o.redirectUrl + "\""
+					line = l + "=" + "\"" + o.redirectURL + "\""
 				case "oidc_issuer_url":
-					line = l + "=" + "\"" + o.oidcIssuerUrl + "\""
+					line = l + "=" + "\"" + o.oidcIssuerURL + "\""
 				case "ssl_insecure_skip_verify":
 					line = l + "=" + "\"" + strconv.FormatBool(o.sslInsecureSkipVerify) + "\""
 				case "insecure_oidc_skip_issuer_verification":
@@ -90,7 +91,7 @@ func (o *oauth2Config) Parse() string {
 		}
 
 		if len(line) > 0 {
-			builder.WriteString(line + "\n")
+			_, _ = builder.WriteString(line + "\n")
 		}
 	}
 
@@ -100,7 +101,7 @@ func (o *oauth2Config) Parse() string {
 }
 
 // NewOAuth2Config returns a new oauth2 config
-func NewOAuth2Config(opts ...optOauth2) configParser {
+func NewOAuth2Config(opts ...OptOauth2) configParser {
 	cfg := oauth2Config{}
 	for _, o := range opts {
 		o(&cfg)
@@ -109,64 +110,64 @@ func NewOAuth2Config(opts ...optOauth2) configParser {
 	return &cfg
 }
 
-// WithClientId sets the client id
-func WithClientId(id string) optOauth2 {
+// WithClientID sets the client id
+func WithClientID(id string) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.clientID = id
 	}
 }
 
-// WithRedirectUrl sets the redirect url
-func WithRedirectUrl(url string) optOauth2 {
+// WithRedirectURL sets the redirect url
+func WithRedirectURL(url string) OptOauth2 {
 	return func(o *oauth2Config) {
-		o.redirectUrl = url
+		o.redirectURL = url
 	}
 }
 
 // WithScope sets the scope
-func WithScope(scope string) optOauth2 {
+func WithScope(scope string) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.scope = scope
 	}
 }
 
 // WithClientSecret sets the client secret
-func WithClientSecret(path string) optOauth2 {
+func WithClientSecret(path string) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.clientSecret = path
 	}
 }
 
 // WithClientSecretFile sets the client secret file
-func WithClientSecretFile(path string) optOauth2 {
+func WithClientSecretFile(path string) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.clientSecretFile = path
 	}
 }
 
-// WithOidcIssuerUrl sets the oidc issuer url
-func WithOidcIssuerUrl(url string) optOauth2 {
+// WithOidcIssuerURL sets the oidc issuer url
+func WithOidcIssuerURL(url string) OptOauth2 {
 	return func(o *oauth2Config) {
-		o.oidcIssuerUrl = url
+		o.oidcIssuerURL = url
 	}
 }
 
 // EnableSslInsecureSkipVerify sets the ssl insecure skip verify
-func EnableSslInsecureSkipVerify(b bool) optOauth2 {
+func EnableSslInsecureSkipVerify(b bool) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.sslInsecureSkipVerify = b
 	}
 }
 
 // EnableInsecureOidcSkipIssuerVerification sets the insecure oidc skip issuer verification
-func EnableInsecureOidcSkipIssuerVerification(b bool) optOauth2 {
+func EnableInsecureOidcSkipIssuerVerification(b bool) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.insecureOidcSkipIssuerVerification = b
 	}
 }
 
 // EnableInsecureOidcSkipNonce sets the insecure oidc skip nonce
-func EnableInsecureOidcSkipNonce(b bool) optOauth2 {
+func EnableInsecureOidcSkipNonce(b bool) OptOauth2 {
 	return func(o *oauth2Config) {
 		o.insecureOidcSkipNonce = b
 	}

--- a/pkg/configuration/resource-attributes-template.go
+++ b/pkg/configuration/resource-attributes-template.go
@@ -48,10 +48,11 @@ func (r *root) Parse() string {
 	return string(parsed)
 }
 
-type optRAttributes func(*ResourceAttributes)
+// OptRAttributes is a function that modifies the ResourceAttributes
+type OptRAttributes func(*ResourceAttributes)
 
 // NewResourceAttributes returns a new configParser for the ResourceAttributes
-func NewResourceAttributes(opt ...optRAttributes) configParser {
+func NewResourceAttributes(opt ...OptRAttributes) configParser {
 	root := &root{
 		Authorization: Authorization{
 			ResourceAttributes: ResourceAttributes{
@@ -73,14 +74,14 @@ func NewResourceAttributes(opt ...optRAttributes) configParser {
 }
 
 // WithNamespace sets the namespace for the ResourceAttributes
-func WithNamespace(namespace string) optRAttributes {
+func WithNamespace(namespace string) OptRAttributes {
 	return func(r *ResourceAttributes) {
 		r.Namespace = namespace
 	}
 }
 
 // WithSubresource sets the subresource for the ResourceAttributes
-func WithSubresource(subresource string) optRAttributes {
+func WithSubresource(subresource string) OptRAttributes {
 	return func(r *ResourceAttributes) {
 		r.Subresource = subresource
 	}

--- a/pkg/constants/const.go
+++ b/pkg/constants/const.go
@@ -37,7 +37,7 @@ const (
 	// ContainerNameKubeRbacProxy is the name of the kube-rbac-proxy container
 	ContainerNameKubeRbacProxy = "kube-rbac-proxy"
 	// SecretNameOauth2Proxy is the name of the kube-rbac-proxy container
-	SecretNameOauth2Proxy = "oauth2-proxy" //#nosec G101 -- This is a false positive
+	SecretNameOauth2Proxy = "oauth2-proxy" // #nosec G101 -- This is a false positive
 	// SecretNameResourceAttributes is the name of the resource attributes secret
 	SecretNameResourceAttributes = "resource-attributes"
 	// SecretNameKubeconfig is the name of the kubeconfig secret
@@ -76,14 +76,14 @@ const (
 	// KubeRbacProxyVolumeName is the volume name of the kube-rbac-proxy configuration
 	KubeRbacProxyVolumeName = "kube-rbac-proxy"
 
-	// GARDEN_KUBECONFIG is an environment variable pointing at the default extension access token, if the custom one is not provided
-	GARDEN_KUBECONFIG = "GARDEN_KUBECONFIG"
-	// GARDEN_ACCESS_TOKEN is an environment variable pointing at a custom access token
-	GARDEN_ACCESS_TOKEN = "GARDEN_ACCESS_TOKEN"
-	// GARDEN_NAMESPACE is the default k8s namespace containing seed workloads
-	GARDEN_NAMESPACE = "garden"
-	// GARDEN_SEED_DOMAIN_NAME is the default domain name of the seed cluster, where the extension is running
-	GARDEN_SEED_DOMAIN_NAME = "GARDEN_SEED_DOMAIN_NAME"
-	// GARDEN_SEED_OAUTH2_PROXY_CLIENT_ID is the oidc clientId for the seed cluster, where the extension is running
-	GARDEN_SEED_OAUTH2_PROXY_CLIENT_ID = "GARDEN_SEED_OAUTH2_PROXY_CLIENT_ID"
+	// GardenKubeconfig is an environment variable pointing at the default extension access token, if the custom one is not provided
+	GardenKubeconfig = "GARDEN_KUBECONFIG"
+	// GardenAccessToken is an environment variable pointing at a custom access token
+	GardenAccessToken = "GARDEN_ACCESS_TOKEN"
+	// GardenNamespace is the default k8s namespace containing seed workloads
+	GardenNamespace = "garden"
+	// GardenSeedDomainName is the default domain name of the seed cluster, where the extension is running
+	GardenSeedDomainName = "GARDEN_SEED_DOMAIN_NAME"
+	// GardenSeedOauth2ProxyClientID is the oidc clientId for the seed cluster, where the extension is running
+	GardenSeedOauth2ProxyClientID = "GARDEN_SEED_OAUTH2_PROXY_CLIENT_ID"
 )

--- a/pkg/controllers/image-pull-secret-reconciler.go
+++ b/pkg/controllers/image-pull-secret-reconciler.go
@@ -23,7 +23,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 )
 
 const (

--- a/pkg/controllers/modifiers.go
+++ b/pkg/controllers/modifiers.go
@@ -24,7 +24,7 @@ import (
 
 	gardencorev1beta1 "github.com/gardener/gardener/pkg/apis/core/v1beta1"
 	gardenextensionsv1alpha1 "github.com/gardener/gardener/pkg/apis/extensions/v1alpha1"
-	v1 "k8s.io/api/apps/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/gardener/oidc-apps-controller/pkg/configuration"
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 )
 
 func fetchOidcAppsServices(ctx context.Context, c client.Client, object client.Object) (*corev1.ServiceList, error) {
@@ -122,12 +122,12 @@ func fetchOidcAppsSecrets(ctx context.Context, c client.Client, object client.Ob
 func fetchResourceAttributesNamespace(ctx context.Context, c client.Client, object client.Object) string {
 	_log := log.FromContext(ctx)
 	// In the case when we are not running on a gardener seed cluster, just return the target namespace
-	if os.Getenv(constants.GARDEN_KUBECONFIG) == "" {
+	if os.Getenv(constants.GardenKubeconfig) == "" {
 		return object.GetNamespace()
 	}
 	// In the case the target is in the garden namespace, then we shall not set a namespace.
 	// The goal is the kick in only the gardener operators access which should have cluster scoped access
-	if object.GetNamespace() == constants.GARDEN_NAMESPACE {
+	if object.GetNamespace() == constants.GardenNamespace {
 		return ""
 	}
 	// In other cases, fetch the cluster resources and set the project namespace
@@ -161,7 +161,7 @@ func fetchResourceAttributesNamespace(ctx context.Context, c client.Client, obje
 
 // reconcileDeploymentDependencies is the function responsible for managing authentication & authorization dependencies.
 // It reconciles the needed secrets, ingresses and services.
-func reconcileDeploymentDependencies(ctx context.Context, c client.Client, object *v1.Deployment) error {
+func reconcileDeploymentDependencies(ctx context.Context, c client.Client, object *appsv1.Deployment) error {
 	var (
 		// Service for the oauth2-proxy sidecar
 		oauth2Service corev1.Service
@@ -270,7 +270,7 @@ func reconcileDeploymentDependencies(ctx context.Context, c client.Client, objec
 	return patchVpa(ctx, c, object)
 }
 
-func reconcileStatefulSetDependencies(ctx context.Context, c client.Client, object *v1.StatefulSet) error {
+func reconcileStatefulSetDependencies(ctx context.Context, c client.Client, object *appsv1.StatefulSet) error {
 	var (
 		// Service for the oauth2-proxy sidecar
 		oauth2Service corev1.Service
@@ -590,7 +590,7 @@ func hasOidcAppsPods(ctx context.Context, c client.Client, object client.Object)
 					return true
 				}
 			case "ReplicaSet":
-				rs := &v1.ReplicaSet{}
+				rs := &appsv1.ReplicaSet{}
 				if err := c.Get(ctx, types.NamespacedName{Name: ref.Name, Namespace: object.GetNamespace()}, rs); client.IgnoreNotFound(err) != nil {
 					log.FromContext(ctx).Error(err, "cannot get replicaset", "name", ref.Name)
 

--- a/pkg/controllers/namespace-reconciler.go
+++ b/pkg/controllers/namespace-reconciler.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 )
 
 // NamespaceReconciler holds configuration for the reconciler

--- a/pkg/controllers/oidc-apps-ingresses.go
+++ b/pkg/controllers/oidc-apps-ingresses.go
@@ -25,7 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/gardener/oidc-apps-controller/pkg/configuration"
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 	"github.com/gardener/oidc-apps-controller/pkg/rand"
 )
 

--- a/pkg/controllers/oidc-apps-secrets.go
+++ b/pkg/controllers/oidc-apps-secrets.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/gardener/oidc-apps-controller/pkg/configuration"
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 	"github.com/gardener/oidc-apps-controller/pkg/rand"
 )
 
@@ -43,22 +43,22 @@ func createOauth2Secret(object client.Object) (corev1.Secret, error) {
 	switch extConfig.GetClientSecret(object) {
 	case "":
 		cfg = configuration.NewOAuth2Config(
-			configuration.WithClientId(extConfig.GetClientID(object)),
+			configuration.WithClientID(extConfig.GetClientID(object)),
 			configuration.WithClientSecretFile("/dev/null"),
 			configuration.WithScope(extConfig.GetScope(object)),
-			configuration.WithRedirectUrl(extConfig.GetRedirectUrl(object)),
-			configuration.WithOidcIssuerUrl(extConfig.GetOidcIssuerUrl(object)),
+			configuration.WithRedirectURL(extConfig.GetRedirectURL(object)),
+			configuration.WithOidcIssuerURL(extConfig.GetOidcIssuerURL(object)),
 			configuration.EnableSslInsecureSkipVerify(extConfig.GetSslInsecureSkipVerify(object)),
 			configuration.EnableInsecureOidcSkipIssuerVerification(extConfig.GetInsecureOidcSkipIssuerVerification(object)),
 			configuration.EnableInsecureOidcSkipNonce(extConfig.GetInsecureOidcSkipNonce(object))).Parse()
 
 	default:
 		cfg = configuration.NewOAuth2Config(
-			configuration.WithClientId(extConfig.GetClientID(object)),
+			configuration.WithClientID(extConfig.GetClientID(object)),
 			configuration.WithClientSecret(extConfig.GetClientSecret(object)),
 			configuration.WithScope(extConfig.GetScope(object)),
-			configuration.WithRedirectUrl(extConfig.GetRedirectUrl(object)),
-			configuration.WithOidcIssuerUrl(extConfig.GetOidcIssuerUrl(object)),
+			configuration.WithRedirectURL(extConfig.GetRedirectURL(object)),
+			configuration.WithOidcIssuerURL(extConfig.GetOidcIssuerURL(object)),
 			configuration.EnableSslInsecureSkipVerify(extConfig.GetSslInsecureSkipVerify(object)),
 			configuration.EnableInsecureOidcSkipIssuerVerification(extConfig.GetInsecureOidcSkipIssuerVerification(object)),
 			configuration.EnableInsecureOidcSkipNonce(extConfig.GetInsecureOidcSkipNonce(object))).Parse()

--- a/pkg/controllers/oidc-apps-services.go
+++ b/pkg/controllers/oidc-apps-services.go
@@ -22,7 +22,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 	"github.com/gardener/oidc-apps-controller/pkg/rand"
 )
 

--- a/pkg/notifiers/gardener-access-token.go
+++ b/pkg/notifiers/gardener-access-token.go
@@ -28,7 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/yaml"
 
-	constants "github.com/gardener/oidc-apps-controller/pkg/constants"
+	"github.com/gardener/oidc-apps-controller/pkg/constants"
 )
 
 var _ manager.Runnable = &gardenerAccessTokenNotifier{}

--- a/pkg/oidc-apps-controller/options.go
+++ b/pkg/oidc-apps-controller/options.go
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package oidc_apps_controller
+package oidcappscontroller
 
 import "github.com/spf13/pflag"
 
-// OidcAppsControllerOptions holds th controller starup parameters
-type OidcAppsControllerOptions struct {
+// Options holds th controller starup parameters
+type Options struct {
 	useCertManager       bool
 	webhookPort          int
 	metricsPort          int
@@ -29,20 +29,20 @@ type OidcAppsControllerOptions struct {
 }
 
 // AddFlags adds the controller parameters to the flag set
-func (o *OidcAppsControllerOptions) AddFlags(pflag *pflag.FlagSet) {
-	pflag.StringVar(&o.controllerConfigPath, "config", "extension-config.yaml",
+func (o *Options) AddFlags(flagSet *pflag.FlagSet) {
+	flagSet.StringVar(&o.controllerConfigPath, "config", "extension-config.yaml",
 		"The file path to the extension configuration yaml.")
-	pflag.StringVar(&o.registrySecret, "registry-secret", "",
+	flagSet.StringVar(&o.registrySecret, "registry-secret", "",
 		"The image pull secret for pull oidc-apps-controller container images")
-	pflag.BoolVar(&o.useCertManager, "use-cert-manager", false,
+	flagSet.BoolVar(&o.useCertManager, "use-cert-manager", false,
 		"Denotes if the webhook certificates are externally managed by a cert-manager.io instance or by this controller.")
-	pflag.StringVar(&o.webhookCertsDir, "webhook-certs-dir", "./certs",
+	flagSet.StringVar(&o.webhookCertsDir, "webhook-certs-dir", "./certs",
 		"The directory containing webhook serving tls.key, tls.crt certificates")
-	pflag.StringVar(&o.webhookName, "webhook-name", "oidc-apps-controller",
+	flagSet.StringVar(&o.webhookName, "webhook-name", "oidc-apps-controller",
 		"The name of the oidc-apps controller webhook ")
-	pflag.IntVar(&o.webhookPort, "webhook-port", 10250,
+	flagSet.IntVar(&o.webhookPort, "webhook-port", 10250,
 		"The port of the oidc-apps controller webhook ")
-	pflag.IntVar(&o.metricsPort, "metrics-port", 8080,
+	flagSet.IntVar(&o.metricsPort, "metrics-port", 8080,
 		"The port of the oidc-apps controller metrics endpoint ")
-	pflag.StringVar(&o.cacheSelectorString, "cache-selector", "", "The selector string for controller-runtime cache.")
+	flagSet.StringVar(&o.cacheSelectorString, "cache-selector", "", "The selector string for controller-runtime cache.")
 }

--- a/pkg/rand/rand.go
+++ b/pkg/rand/rand.go
@@ -38,7 +38,7 @@ func GenerateRandomString(length int) string {
 			return ""
 		}
 
-		b.WriteByte(charset[index.Int64()])
+		_ = b.WriteByte(charset[index.Int64()])
 	}
 
 	return b.String()

--- a/pkg/webhook/modifiers.go
+++ b/pkg/webhook/modifiers.go
@@ -58,22 +58,22 @@ func get2ProxySecretChecksum(object client.Object) string {
 	switch extConfig.GetClientSecret(object) {
 	case "":
 		cfg = configuration.NewOAuth2Config(
-			configuration.WithClientId(extConfig.GetClientID(object)),
+			configuration.WithClientID(extConfig.GetClientID(object)),
 			configuration.WithClientSecretFile("/dev/null"),
 			configuration.WithScope(extConfig.GetScope(object)),
-			configuration.WithRedirectUrl(extConfig.GetRedirectUrl(object)),
-			configuration.WithOidcIssuerUrl(extConfig.GetOidcIssuerUrl(object)),
+			configuration.WithRedirectURL(extConfig.GetRedirectURL(object)),
+			configuration.WithOidcIssuerURL(extConfig.GetOidcIssuerURL(object)),
 			configuration.EnableSslInsecureSkipVerify(extConfig.GetSslInsecureSkipVerify(object)),
 			configuration.EnableInsecureOidcSkipIssuerVerification(extConfig.GetInsecureOidcSkipIssuerVerification(object)),
 			configuration.EnableInsecureOidcSkipNonce(extConfig.GetInsecureOidcSkipNonce(object)),
 		).Parse()
 	default:
 		cfg = configuration.NewOAuth2Config(
-			configuration.WithClientId(extConfig.GetClientID(object)),
+			configuration.WithClientID(extConfig.GetClientID(object)),
 			configuration.WithClientSecret(extConfig.GetClientSecret(object)),
 			configuration.WithScope(extConfig.GetScope(object)),
-			configuration.WithRedirectUrl(extConfig.GetRedirectUrl(object)),
-			configuration.WithOidcIssuerUrl(extConfig.GetOidcIssuerUrl(object)),
+			configuration.WithRedirectURL(extConfig.GetRedirectURL(object)),
+			configuration.WithOidcIssuerURL(extConfig.GetOidcIssuerURL(object)),
 			configuration.EnableSslInsecureSkipVerify(extConfig.GetSslInsecureSkipVerify(object)),
 			configuration.EnableInsecureOidcSkipIssuerVerification(extConfig.GetInsecureOidcSkipIssuerVerification(object)),
 			configuration.EnableInsecureOidcSkipNonce(extConfig.GetInsecureOidcSkipNonce(object)),
@@ -166,7 +166,7 @@ func addProjectedSecretSourceVolume(volumeName, secretName string, podSpec *core
 		LocalObjectReference: corev1.LocalObjectReference{
 			Name: secretName,
 		},
-		//Items:    nil,
+		// Items:    nil,
 		Optional: ptr.To(false),
 	}
 
@@ -272,7 +272,7 @@ func fetchTargetSuffix(object client.Object) string {
 	return suffix
 }
 
-func fetchUpstreamUrl(target string, podSpec corev1.PodSpec) string {
+func buildUpstreamURL(target string, podSpec corev1.PodSpec) string {
 	before, after, _ := strings.Cut(target, ",")
 
 	protocol, f := strings.CutPrefix(before, "protocol=")
@@ -303,7 +303,7 @@ func fetchUpstreamUrl(target string, podSpec corev1.PodSpec) string {
 	return ""
 }
 
-func getKubeRbacProxyContainer(clientID, issuerUrl, upstream string, pod *corev1.Pod, owner client.Object) corev1.Container {
+func getKubeRbacProxyContainer(clientID, issuerURL, upstream string, pod *corev1.Pod, owner client.Object) corev1.Container {
 	image, _ := imagevector.ImageVector().FindImage("kube-rbac-proxy-watcher")
 
 	if pod == nil {
@@ -371,7 +371,7 @@ func getKubeRbacProxyContainer(clientID, issuerUrl, upstream string, pod *corev1
 		ImagePullPolicy: "IfNotPresent",
 		Args: []string{"--insecure-listen-address=0.0.0.0:8100",
 			"--oidc-clientID=" + clientID,
-			"--oidc-issuer=" + issuerUrl,
+			"--oidc-issuer=" + issuerURL,
 			"--upstream=" + upstream,
 			"--config-file=/etc/kube-rbac-proxy/config-file.yaml"},
 		Ports: []corev1.ContainerPort{

--- a/pkg/webhook/pod-webhook.go
+++ b/pkg/webhook/pod-webhook.go
@@ -72,10 +72,10 @@ func (p *PodMutator) Handle(ctx context.Context, req webhook.AdmissionRequest) w
 	_log.Info("handling pod admission request")
 
 	patch := pod.DeepCopy()
-	clientId := configuration.GetOIDCAppsControllerConfig().GetClientID(owner)
-	issuerUrl := configuration.GetOIDCAppsControllerConfig().GetOidcIssuerUrl(owner)
+	clientID := configuration.GetOIDCAppsControllerConfig().GetClientID(owner)
+	ussuerURL := configuration.GetOIDCAppsControllerConfig().GetOidcIssuerURL(owner)
 	upstream := configuration.GetOIDCAppsControllerConfig().GetUpstreamTarget(owner)
-	upstreamUrl := fetchUpstreamUrl(upstream, patch.Spec)
+	upstreamURL := buildUpstreamURL(upstream, patch.Spec)
 	suffix := fetchTargetSuffix(owner)
 
 	// Add the OIDC annotation to the deployment template
@@ -139,8 +139,8 @@ func (p *PodMutator) Handle(ctx context.Context, req webhook.AdmissionRequest) w
 	addProxyContainer(constants.ContainerNameOauth2Proxy, &patch.Spec, getOIDCProxyContainer(&patch.Spec, owner))
 
 	// Add the kube-rbac-proxy sidecar to the pod template
-	addProxyContainer(constants.ContainerNameKubeRbacProxy, &patch.Spec, getKubeRbacProxyContainer(clientId,
-		issuerUrl, upstreamUrl, patch, owner))
+	addProxyContainer(constants.ContainerNameKubeRbacProxy, &patch.Spec, getKubeRbacProxyContainer(clientID,
+		ussuerURL, upstreamURL, patch, owner))
 
 	// Add image pull secret if the proxy container images are served from private registry
 	if len(p.ImagePullSecret) > 0 {

--- a/pkg/webhook/test/pod-mutating-webhook_test.go
+++ b/pkg/webhook/test/pod-mutating-webhook_test.go
@@ -48,7 +48,6 @@ var targetPod, targetPodWithServiceAccount, podWithLessResources, podWithMoreRes
 var podWebhook *webhook.PodMutator
 
 var _ = BeforeEach(func() {
-
 	initNonTargetDeployment()
 	initTargetDeployment()
 
@@ -73,7 +72,6 @@ var _ = BeforeEach(func() {
 		Client:  fakeClient,
 		Decoder: admission.NewDecoder(s),
 	}
-
 })
 
 func initTargetDeployment() {
@@ -292,7 +290,6 @@ func initNonTargetDeployment() {
 }
 
 var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
-
 	Context("when a pod belongs to a target", func() {
 		It("there shall be auth & authz proxies in the patch pod spec", func() {
 			patchedPod := patchPod(targetPod)
@@ -381,8 +378,6 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 							ReadOnly:  true,
 							MountPath: "/etc/oauth2-proxy",
 						}))
-				}
-				switch c.Name {
 				case constants.ContainerNameKubeRbacProxy:
 					Expect(c.VolumeMounts).To(ContainElement(
 						corev1.VolumeMount{
@@ -479,8 +474,7 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 				_log.Info("patched pod", "patched pod", pp)
 
 				for _, c := range pp.Spec.Containers {
-					switch c.Name {
-					case constants.ContainerNameOauth2Proxy:
+					if c.Name == constants.ContainerNameOauth2Proxy {
 						Expect(c.Resources).To(Equal(corev1.ResourceRequirements{
 							Limits: corev1.ResourceList{
 								"cpu":    resource.MustParse("100m"),
@@ -499,11 +493,11 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 		When("there is a container resource defined in the incoming request which are bigger than default", func() {
 			It("shall not modify the container resources", func() {
 				pp := patchPod(podWithMoreResources)
+
 				_log.Info("patched pod", "patched pod", pp)
 
 				for _, c := range pp.Spec.Containers {
-					switch c.Name {
-					case constants.ContainerNameOauth2Proxy:
+					if c.Name == constants.ContainerNameOauth2Proxy {
 						Expect(c.Resources).To(Equal(podWithMoreResources.Spec.Containers[1].Resources))
 					}
 				}
@@ -512,11 +506,11 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 		When("there isn't any container resource defined in the incoming request", func() {
 			It("shall set the default container resources", func() {
 				pp := patchPod(podWithLessResources)
+
 				_log.Info("patched pod", "patched pod", pp)
 
 				for _, c := range pp.Spec.Containers {
-					switch c.Name {
-					case constants.ContainerNameKubeRbacProxy:
+					if c.Name == constants.ContainerNameKubeRbacProxy {
 						expected := corev1.ResourceRequirements{
 							Limits: map[corev1.ResourceName]resource.Quantity{
 								"cpu":    resource.MustParse("100m"),

--- a/pkg/webhook/test/vpa-mutating-webhook_test.go
+++ b/pkg/webhook/test/vpa-mutating-webhook_test.go
@@ -149,7 +149,6 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 				ContainerName: constants.ContainerNameKubeRbacProxy,
 				Mode:          ptr.To(autoscalerv1.ContainerScalingModeOff),
 			}))
-
 		})
 	})
 
@@ -175,7 +174,6 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 			Expect(resp.Patches).To(BeNil())
 		}) // It
 	})
-
 })
 
 func patchVpa(vpa *autoscalerv1.VerticalPodAutoscaler) *autoscalerv1.VerticalPodAutoscaler {

--- a/test/e2e/deployment_test.go
+++ b/test/e2e/deployment_test.go
@@ -33,9 +33,7 @@ import (
 )
 
 var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
-
 	Context("when a deployment is a target", Ordered, func() {
-
 		var (
 			deployment *appsv1.Deployment
 			replicaSet *appsv1.ReplicaSet
@@ -63,7 +61,7 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 				return clt.Create(ctx, pod)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 
-			suffix = rand.GenerateSha256(strings.Join([]string{target, default_namespace}, "-"))
+			suffix = rand.GenerateSha256(strings.Join([]string{target, defaultNamespace}, "-"))
 		}, NodeTimeout(5*time.Second))
 
 		AfterAll(func(ctx SpecContext) {
@@ -74,24 +72,22 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 		}, NodeTimeout(5*time.Second))
 
 		It("there shall be auth & authz sidecar containers present in the deployment pod", func() {
-
 			pod := &corev1.Pod{}
+
 			Expect(clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
-					Name:      nginx_pod,
+					Namespace: defaultNamespace,
+					Name:      nginxPod,
 				},
 				pod)).Should(Succeed())
-
 			Expect(pod.Spec.Containers).Should(HaveLen(3))
-
 		})
 
 		It("there shall be an oidc-apps annotated ingress present in the deployment namespace", func(ctx SpecContext) {
 			ingresses := networkingv1.IngressList{}
 			Eventually(func() error {
 				if err = clt.List(ctx, &ingresses,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.LabelKey: constants.LabelValue,
@@ -123,7 +119,7 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 			services := corev1.ServiceList{}
 			Eventually(func() error {
 				if err = clt.List(ctx, &services,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.LabelKey: constants.LabelValue,
@@ -143,11 +139,10 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 		})
 
 		It("there shall be an oauth2 secret present in the deployment namespace", func(ctx SpecContext) {
-
 			secrets := corev1.SecretList{}
 			Eventually(func() error {
 				if err = clt.List(ctx, &secrets,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.SecretLabelKey: constants.Oauth2LabelValue,
@@ -173,7 +168,7 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 			secrets := corev1.SecretList{}
 			Eventually(func() error {
 				if err = clt.List(ctx, &secrets,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.SecretLabelKey: constants.RbacLabelValue,
@@ -223,7 +218,7 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 			Eventually(func() error {
 				return clt.Create(ctx, pod)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
-			suffix = rand.GenerateSha256(strings.Join([]string{non_target, default_namespace}, "-"))
+			suffix = rand.GenerateSha256(strings.Join([]string{nonTarget, defaultNamespace}, "-"))
 		}, NodeTimeout(5*time.Second))
 
 		AfterAll(func(ctx SpecContext) {
@@ -236,19 +231,18 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 			pod := &corev1.Pod{}
 			Expect(clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
-					Name:      nginx_pod,
+					Namespace: defaultNamespace,
+					Name:      nginxPod,
 				},
 				pod)).Should(Succeed())
 			Expect(pod.Spec.Containers).Should(HaveLen(1))
-
 		})
 
 		It("there shall be no oidc-apps ingress present in the deployment namespace", func() {
 			ingress := &networkingv1.Ingress{}
 			err = clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
+					Namespace: defaultNamespace,
 					Name:      constants.IngressName + "-" + suffix,
 				}, ingress)
 			Expect(err).Should(HaveOccurred())
@@ -259,19 +253,18 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 			service := &corev1.Service{}
 			err := clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
+					Namespace: defaultNamespace,
 					Name:      constants.ServiceNameOauth2Service + "-" + suffix,
 				}, service)
 			Expect(err).Should(HaveOccurred())
 			Expect(errors.IsNotFound(err)).Should(BeTrue())
-
 		})
 
 		It("there shall be no oauth2 secret present in the deployment namespace", func() {
 			secret := &corev1.Secret{}
 			err := clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
+					Namespace: defaultNamespace,
 					Name:      constants.SecretNameOauth2Proxy + "-" + suffix,
 				}, secret)
 			Expect(err).Should(HaveOccurred())
@@ -282,7 +275,7 @@ var _ = Describe("Oidc Apps Deployment Target Test", Ordered, func() {
 			secret := &corev1.Secret{}
 			err := clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
+					Namespace: defaultNamespace,
 					Name:      constants.SecretNameResourceAttributes + "-" + suffix,
 				}, secret)
 			Expect(err).Should(HaveOccurred())

--- a/test/e2e/setup.go
+++ b/test/e2e/setup.go
@@ -29,10 +29,10 @@ import (
 )
 
 const (
-	default_namespace = "default"
-	target            = "nginx"
-	non_target        = "nginx-non-target"
-	nginx_pod         = "nginx-pod"
+	defaultNamespace = "default"
+	target           = "nginx"
+	nonTarget        = "nginx-non-target"
+	nginxPod         = "nginx-pod"
 )
 
 func installWebHooks(env *envtest.Environment) {
@@ -66,7 +66,7 @@ func installWebHooks(env *envtest.Environment) {
 						ClientConfig: admissionv1.WebhookClientConfig{
 							Service: &admissionv1.ServiceReference{
 								Name:      "webhook-service",
-								Namespace: default_namespace,
+								Namespace: defaultNamespace,
 								Path:      ptr.To(constants.PodWebHookPath),
 							},
 						},
@@ -87,7 +87,7 @@ func createTargetDeployment() *appsv1.Deployment {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      target,
-			Namespace: default_namespace,
+			Namespace: defaultNamespace,
 			Labels:    map[string]string{"app": target},
 			UID:       "1234",
 		},
@@ -118,7 +118,7 @@ func createReplicaSet(owner client.Object) *appsv1.ReplicaSet {
 	return &appsv1.ReplicaSet{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "nginx-replicaset",
-			Namespace: default_namespace,
+			Namespace: defaultNamespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(owner, appsv1.SchemeGroupVersion.WithKind("Deployment")),
 			},
@@ -153,8 +153,8 @@ func createPod(owner client.Object) *corev1.Pod {
 			Kind:       "Pod",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      nginx_pod,
-			Namespace: default_namespace,
+			Name:      nginxPod,
+			Namespace: defaultNamespace,
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(owner, appsv1.SchemeGroupVersion.WithKind("ReplicaSet")),
 			},
@@ -178,9 +178,9 @@ func createNonTargetDeployment() *appsv1.Deployment {
 			Kind:       "Deployment",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      non_target,
-			Namespace: default_namespace,
-			Labels:    map[string]string{"app": non_target},
+			Name:      nonTarget,
+			Namespace: defaultNamespace,
+			Labels:    map[string]string{"app": nonTarget},
 			UID:       "1234",
 		},
 		Spec: appsv1.DeploymentSpec{
@@ -213,7 +213,7 @@ func createTargetStatefulSet() *appsv1.StatefulSet {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      target,
-			Namespace: default_namespace,
+			Namespace: defaultNamespace,
 			Labels:    map[string]string{"app": target},
 			UID:       "1234",
 		},
@@ -247,7 +247,7 @@ func createStatefulSetPod(owner client.Object, index string) *corev1.Pod {
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      strings.Join([]string{target, index}, "-"),
-			Namespace: default_namespace,
+			Namespace: defaultNamespace,
 			Labels: map[string]string{
 				"app":                                "nginx",
 				"statefulset.kubernetes.io/pod-name": strings.Join([]string{target, index}, "-"),

--- a/test/e2e/statefulset_test.go
+++ b/test/e2e/statefulset_test.go
@@ -32,7 +32,6 @@ import (
 )
 
 var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
-
 	Context("when a statefulset is a target", Ordered, func() {
 		var (
 			statefulSet       *appsv1.StatefulSet
@@ -60,7 +59,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 				return clt.Create(ctx, pod1)
 			}).WithPolling(100 * time.Millisecond).Should(Succeed())
 
-			suffix = rand.GenerateSha256(strings.Join([]string{target, default_namespace}, "-"))
+			suffix = rand.GenerateSha256(strings.Join([]string{target, defaultNamespace}, "-"))
 		}, NodeTimeout(5*time.Second))
 
 		AfterAll(func(ctx SpecContext) {
@@ -74,7 +73,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			pod := &corev1.Pod{}
 			Expect(clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
+					Namespace: defaultNamespace,
 					Name:      target + "-0",
 				},
 				pod)).Should(Succeed())
@@ -83,7 +82,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			pod = &corev1.Pod{}
 			Expect(clt.Get(ctx,
 				client.ObjectKey{
-					Namespace: default_namespace,
+					Namespace: defaultNamespace,
 					Name:      target + "-1",
 				},
 				pod)).Should(Succeed())
@@ -96,7 +95,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			By("checking the ingress for the first pod")
 			Eventually(func() error {
 				if err = clt.List(ctx, &ingresses,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.LabelKey: constants.LabelValue,
@@ -108,7 +107,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 					return fmt.Errorf("no oidc-apps ingresses are found")
 				}
 				for _, ingress := range ingresses.Items {
-					podSuffix = rand.GenerateSha256(target + "-0-" + default_namespace)
+					podSuffix = rand.GenerateSha256(target + "-0-" + defaultNamespace)
 					if ingress.Name != constants.IngressName+"-0-"+podSuffix {
 						continue
 					}
@@ -127,7 +126,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			By("checking the ingress for the second pod")
 			Eventually(func() error {
 				if err = clt.List(ctx, &ingresses,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.LabelKey: constants.LabelValue,
@@ -139,7 +138,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 					return fmt.Errorf("no oidc-apps ingresses are found")
 				}
 				for _, ingress := range ingresses.Items {
-					podSuffix = rand.GenerateSha256(target + "-1-" + default_namespace)
+					podSuffix = rand.GenerateSha256(target + "-1-" + defaultNamespace)
 					if ingress.Name != constants.IngressName+"-1-"+podSuffix {
 						continue
 					}
@@ -161,7 +160,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			By("checking the service for the first pod")
 			Eventually(func() error {
 				if err = clt.List(ctx, &services,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.LabelKey: constants.LabelValue,
@@ -169,7 +168,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 					}); err != nil {
 					return err
 				}
-				podSuffix = rand.GenerateSha256(target + "-0-" + default_namespace)
+				podSuffix = rand.GenerateSha256(target + "-0-" + defaultNamespace)
 				for _, service := range services.Items {
 					if service.Name == constants.ServiceNameOauth2Service+"-0-"+podSuffix {
 						return nil
@@ -183,7 +182,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			By("checking the service for the second pod")
 			Eventually(func() error {
 				if err = clt.List(ctx, &services,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.LabelKey: constants.LabelValue,
@@ -191,7 +190,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 					}); err != nil {
 					return err
 				}
-				podSuffix = rand.GenerateSha256(target + "-1-" + default_namespace)
+				podSuffix = rand.GenerateSha256(target + "-1-" + defaultNamespace)
 				for _, service := range services.Items {
 					if service.Name == constants.ServiceNameOauth2Service+"-1-"+podSuffix {
 						return nil
@@ -207,7 +206,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			secrets := corev1.SecretList{}
 			Eventually(func() error {
 				if err = clt.List(ctx, &secrets,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.SecretLabelKey: constants.Oauth2LabelValue,
@@ -233,7 +232,7 @@ var _ = Describe("Oidc Apps Statefulset Target Test", Ordered, func() {
 			secrets := corev1.SecretList{}
 			Eventually(func() error {
 				if err = clt.List(ctx, &secrets,
-					client.InNamespace(default_namespace),
+					client.InNamespace(defaultNamespace),
 					client.MatchingLabelsSelector{
 						Selector: labels.SelectorFromSet(map[string]string{
 							constants.SecretLabelKey: constants.RbacLabelValue,

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -46,7 +46,7 @@ import (
 	"github.com/gardener/oidc-apps-controller/pkg/configuration"
 	"github.com/gardener/oidc-apps-controller/pkg/constants"
 	"github.com/gardener/oidc-apps-controller/pkg/controllers"
-	oidc_apps_controller "github.com/gardener/oidc-apps-controller/pkg/oidc-apps-controller"
+	oidcappscontroller "github.com/gardener/oidc-apps-controller/pkg/oidc-apps-controller"
 	oidcappswebhook "github.com/gardener/oidc-apps-controller/pkg/webhook"
 )
 
@@ -71,7 +71,6 @@ var (
 )
 
 var _ = BeforeSuite(func() {
-
 	// Setup oidc-apps-controller configuration
 	configuration.CreateControllerConfigOrDie(filepath.Join("config", "oidc-apps.yaml"))
 
@@ -162,7 +161,7 @@ var _ = BeforeSuite(func() {
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Watches(
 			&corev1.Pod{},
-			handler.EnqueueRequestsFromMapFunc(oidc_apps_controller.PodMapFuncForDeployment(mgr)),
+			handler.EnqueueRequestsFromMapFunc(oidcappscontroller.PodMapFuncForDeployment(mgr)),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Complete(&controllers.DeploymentReconciler{Client: mgr.GetClient()})
 	Expect(err).ShouldNot(HaveOccurred())
@@ -189,11 +188,11 @@ var _ = BeforeSuite(func() {
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Watches(
 			&corev1.Service{},
-			handler.EnqueueRequestsFromMapFunc(oidc_apps_controller.ServiceMapFuncForStatefulset(mgr)),
+			handler.EnqueueRequestsFromMapFunc(oidcappscontroller.ServiceMapFuncForStatefulset(mgr)),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Watches(
 			&networkingv1.Ingress{},
-			handler.EnqueueRequestsFromMapFunc(oidc_apps_controller.IngressMapFuncForStatefulset(mgr)),
+			handler.EnqueueRequestsFromMapFunc(oidcappscontroller.IngressMapFuncForStatefulset(mgr)),
 			builder.WithPredicates(predicate.ResourceVersionChangedPredicate{})).
 		Complete(&controllers.StatefulSetReconciler{Client: mgr.GetClient()})
 	Expect(err).ShouldNot(HaveOccurred())
@@ -206,7 +205,6 @@ var _ = BeforeSuite(func() {
 
 	// Sync manager cache
 	Expect(mgr.GetCache().WaitForCacheSync(ctx)).Should(BeTrue())
-
 })
 
 var _ = AfterSuite(func() {


### PR DESCRIPTION
This PR simplifies the project linter configuration by leveraging the default `revive` linter config.

The default configuration is available at [defaults.toml](https://github.com/mgechev/revive/blob/master/defaults.toml)

```other developer
Simpler linter configuration
```
