### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,10 @@ updates:
     interval: weekly
   commit-message:
       prefix: "chore(deps):"
+# Create PRs for GitHub Actions updates
+- package-ecosystem: "github-actions"
+  directory: /
+  schedule:
+    interval: weekly
+  commit-message:
+      prefix: "chore(deps):"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,8 +10,6 @@ updates:
   schedule:
     interval: weekly
   open-pull-requests-limit: 5
-  ignore:
-    - dependency-name: "github.com/gardener/gardener"
   commit-message:
       prefix: "chore(deps):"
 # Create PRs for golang version updates


### PR DESCRIPTION
This PR updates `dependabot` configuration.

- adds upstream `gardener` dependency
- adds GitHub action updates

```other developer
None
```
