### PR TITLE
Update sidecar containers

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.10"
+    tag: "v0.1.11"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy

--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -11,4 +11,4 @@ images:
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: "v7.8.2"
+    tag: "v7.9.0"


### PR DESCRIPTION
This PR brings updates in the sidecar containers.

- oauth2-proxy is now updated to [v7.9.0](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.9.0)
- kube-rbac-proxy is now updated to [v0.19.1](https://github.com/brancz/kube-rbac-proxy/releases/tag/v0.19.1)

```other user
The authentication and authorization proxy containers are updated to the latest released versions.
- oauth2-proxy v7.9.0
- kube-rbac-proxy v0.19.1
```
