### PR TITLE
Respect target configuration for creating ingress resources

### DIFF
--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -1,16 +1,5 @@
-// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-License-Identifier: Apache-2.0
 
 package configuration
 
@@ -119,39 +108,34 @@ func WithLog(l logr.Logger) Options {
 
 // CreateControllerConfigOrDie initializes the targets configurations or exits the controller when unsuccessful
 func CreateControllerConfigOrDie(path string, opts ...Options) *OIDCAppsControllerConfig {
-	var (
-		cf  []byte
-		err error
-	)
-
 	once.Do(func() {
 		config = &OIDCAppsControllerConfig{}
 		for _, o := range opts {
 			o(config)
 		}
 
-		if cf, err = os.ReadFile(filepath.Clean(path)); err != nil {
-			if config.log.IsZero() {
-				log.SetLogger(zap.New(zap.UseDevMode(true)))
-				config.log = log.Log.WithName("oidcAppsExtensionConfig")
-			}
-
-			config.log.Error(err, "failed to read extension configuration", "path", path)
-			panic("terminating")
+		cf, err := os.ReadFile(filepath.Clean(path))
+		if err != nil {
+			handleError(err, "failed to read extension configuration", path)
 		}
 
 		if err = yaml.Unmarshal(cf, config); err != nil {
-			if config.log.IsZero() {
-				log.SetLogger(zap.New(zap.UseDevMode(true)))
-				config.log = log.Log.WithName("oidcAppsExtensionConfig")
-			}
-
-			config.log.Error(err, "failed to unmarshal extension configuration")
-			panic("terminating")
+			handleError(err, "failed to unmarshal extension configuration", path)
 		}
 	})
 
 	return config
+}
+
+// handleError centralizes error handling logic
+func handleError(err error, message, path string) {
+	if config.log.IsZero() {
+		log.SetLogger(zap.New(zap.UseDevMode(true)))
+		config.log = log.Log.WithName("oidcAppsExtensionConfig")
+	}
+
+	config.log.Error(err, message, "path", path)
+	panic("terminating")
 }
 
 // GetOIDCAppsControllerConfig returns the loaded configuration
@@ -444,6 +428,16 @@ func (c *OIDCAppsControllerConfig) GetInsecureOidcSkipNonce(object client.Object
 	if c.Configuration.Oauth2Proxy != nil &&
 		c.Configuration.Oauth2Proxy.InsecureOidcSkipNonce != nil {
 		return ptr.Deref(c.Configuration.Oauth2Proxy.InsecureOidcSkipNonce, false)
+	}
+
+	return false
+}
+
+// ShallCreateIngress returns true if the target workload shall create an ingress
+func (c *OIDCAppsControllerConfig) ShallCreateIngress(object client.Object) bool {
+	t := c.fetchTarget(object)
+	if t.Ingress != nil {
+		return t.Ingress.Create
 	}
 
 	return false

--- a/pkg/configuration/config_test.go
+++ b/pkg/configuration/config_test.go
@@ -1,16 +1,5 @@
-// Copyright 2024 SAP SE or an SAP affiliate company. All rights reserved. This file is licensed under the Apache Software License, v. 2 except as noted otherwise in the LICENSE file.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// Copyright 2025 SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-License-Identifier: Apache-2.0
 
 package configuration
 
@@ -110,6 +99,7 @@ func TestTargetGlobalKubeSecret(t *testing.T) {
 		Build()
 
 	g.Expect(extensionConfig.GetKubeSecretName(getDeployment("test-03"))).To(Equal("kubeconfig"))
+	g.Expect(extensionConfig.ShallCreateIngress(getDeployment("test-03"))).To(BeFalse())
 }
 
 func TestTargetKubeSecret(t *testing.T) {
@@ -124,6 +114,7 @@ func TestTargetKubeSecret(t *testing.T) {
 		WithObjects(getDeployment("test-02")).
 		Build()
 
+	g.Expect(extensionConfig.ShallCreateIngress(getDeployment("test-02"))).To(BeTrue())
 	g.Expect(extensionConfig.GetKubeSecretName(getDeployment("test-02"))).To(Equal("target-kubeconfig"))
 }
 
@@ -150,6 +141,7 @@ func TestTargetGlobalConfiguration(t *testing.T) {
 	g.Expect(extensionConfig.GetInsecureOidcSkipNonce(target)).To(BeFalse())
 	g.Expect(extensionConfig.GetKubeConfigStr(target)).To(Equal("Imt1YmVjb25maWci"))
 	g.Expect(extensionConfig.GetKubeSecretName(target)).To(Equal("kubeconfig"))
+	g.Expect(extensionConfig.ShallCreateIngress(target)).To(BeFalse())
 }
 
 func TestTargetConfiguration(t *testing.T) {

--- a/pkg/controllers/oidc-apps-ingresses_test.go
+++ b/pkg/controllers/oidc-apps-ingresses_test.go
@@ -1,0 +1,62 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestFetchStrIndexIfPresent(t *testing.T) {
+	// Test case: Label is present
+	t.Run("Label present", func(t *testing.T) {
+		// Create a fake object with the label
+		obj := &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"statefulset.kubernetes.io/pod-name": "nginx-1-2",
+				},
+			},
+		}
+
+		// Call the function
+		index := fetchStrIndexIfPresent(obj)
+
+		// Assert the result
+		assert.Equal(t, "2", index, "Expected index to be '2'")
+	})
+
+	// Test case: Label is present with double digit index
+	t.Run("Label present with double digit index", func(t *testing.T) {
+		// Create a fake object with the label
+		obj := &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{
+					"statefulset.kubernetes.io/pod-name": "nginx-1-20",
+				},
+			},
+		}
+
+		// Call the function
+		index := fetchStrIndexIfPresent(obj)
+
+		// Assert the result
+		assert.Equal(t, "20", index, "Expected index to be '20'")
+	})
+
+	// Test case: Label is missing
+	t.Run("Label missing", func(t *testing.T) {
+		// Create a fake object without the label
+		obj := &metav1.PartialObjectMetadata{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: map[string]string{},
+			},
+		}
+
+		// Call the function
+		index := fetchStrIndexIfPresent(obj)
+
+		// Assert the result
+		assert.Equal(t, "", index, "Expected index to be an empty string")
+	})
+}

--- a/test/e2e/config/oidc-apps.yaml
+++ b/test/e2e/config/oidc-apps.yaml
@@ -3,12 +3,18 @@ configuration:
   kubeRbacProxy:
   domainName: "example.com"
 targets:
-  - name: "nginx"
+  - name: "nginx-target"
     labelSelector:
       matchLabels:
-        app: nginx
+        app: nginx-target
     ingress:
-      enabled: true
+      create: true
       ingressClassName: "nginx"
       annotations:
         nginx.ingress.kubernetes.io/rewrite-target: /
+  - name: "nginx-target-skip-ingress"
+    labelSelector:
+      matchLabels:
+        app: nginx-target-skip-ingress
+    ingress:
+      create: false

--- a/test/e2e/config/oidc-apps.yaml
+++ b/test/e2e/config/oidc-apps.yaml
@@ -18,3 +18,15 @@ targets:
         app: nginx-target-skip-ingress
     ingress:
       create: false
+  - name: "nginx-target-with-oauth2-redirect"
+    configuration:
+        oauth2Proxy:
+            redirectUrl: "https://custom.redirect.url/oauth2/callback"
+    labelSelector:
+      matchLabels:
+        app: nginx-target-with-oauth2-redirect
+    ingress:
+      create: true
+      ingressClassName: "nginx"
+
+


### PR DESCRIPTION
This PR fixes ingress resource creation for the authentication sidecar.
Now the ingress resource is not created when is disabled in the target configuration.

For example with following target configuration
```
target:
  - name:
    ingress:
      create: false
```
the `oidc-apps-controller` will not create an `Ingress` resource for the `oauth2-proxy` sidecar.
     


```feature user

```
