### PR TITLE
Update authorization side-car image

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -7,7 +7,7 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.11"
+    tag: "v0.1.12"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR brings the latest version of kube-rbac-proxy-watcher side-car container image.

```other developer
kube-rbac-proxy-watcher is now updated to v0.1.12
```
