### PR TITLE
Remove side-cars container limits

### DIFF
--- a/pkg/webhook/modifiers.go
+++ b/pkg/webhook/modifiers.go
@@ -337,10 +337,6 @@ func getKubeRbacProxyContainer(clientID, issuerURL, upstream string, pod *corev1
 	}
 
 	containerResourceRequirements := corev1.ResourceRequirements{
-		Limits: map[corev1.ResourceName]resource.Quantity{
-			"cpu":    resource.MustParse("100m"),
-			"memory": resource.MustParse("100Mi"),
-		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			"cpu":    resource.MustParse("5m"),
 			"memory": resource.MustParse("32Mi"),
@@ -350,12 +346,6 @@ func getKubeRbacProxyContainer(clientID, issuerURL, upstream string, pod *corev1
 	for _, c := range pod.Spec.Containers {
 		if c.Name != constants.ContainerNameKubeRbacProxy {
 			continue
-		}
-
-		if !reflect.ValueOf(c.Resources.Limits).IsZero() {
-			if c.Resources.Limits.Memory().Cmp(resource.MustParse("100Mi")) > 0 {
-				containerResourceRequirements.Limits = c.Resources.Limits
-			}
 		}
 
 		if !reflect.ValueOf(c.Resources.Requests).IsZero() {
@@ -416,10 +406,6 @@ func getOIDCProxyContainer(pod *corev1.PodSpec, owner client.Object) corev1.Cont
 	}
 
 	containerResourceRequirements := corev1.ResourceRequirements{
-		Limits: map[corev1.ResourceName]resource.Quantity{
-			"cpu":    resource.MustParse("100m"),
-			"memory": resource.MustParse("100Mi"),
-		},
 		Requests: map[corev1.ResourceName]resource.Quantity{
 			"cpu":    resource.MustParse("5m"),
 			"memory": resource.MustParse("32Mi"),
@@ -429,12 +415,6 @@ func getOIDCProxyContainer(pod *corev1.PodSpec, owner client.Object) corev1.Cont
 	for _, c := range pod.Containers {
 		if c.Name != constants.ContainerNameOauth2Proxy {
 			continue
-		}
-
-		if !reflect.ValueOf(c.Resources.Limits).IsZero() {
-			if c.Resources.Limits.Memory().Cmp(resource.MustParse("100Mi")) > 0 {
-				containerResourceRequirements.Limits = c.Resources.Limits
-			}
 		}
 
 		if !reflect.ValueOf(c.Resources.Requests).IsZero() {

--- a/pkg/webhook/test/pod-mutating-webhook_test.go
+++ b/pkg/webhook/test/pod-mutating-webhook_test.go
@@ -176,12 +176,8 @@ func initTargetDeployment() {
 					Name: constants.ContainerNameOauth2Proxy,
 					Resources: corev1.ResourceRequirements{
 						Requests: map[corev1.ResourceName]resource.Quantity{
-							"cpu":    resource.MustParse("20m"),
-							"memory": resource.MustParse("32Mi"),
-						},
-						Limits: map[corev1.ResourceName]resource.Quantity{
-							"cpu":    resource.MustParse("200m"),
-							"memory": resource.MustParse("64Mi"),
+							"cpu":    resource.MustParse("1m"),
+							"memory": resource.MustParse("10Mi"),
 						},
 					},
 				},
@@ -216,10 +212,6 @@ func initTargetDeployment() {
 					Name: constants.ContainerNameOauth2Proxy,
 					Resources: corev1.ResourceRequirements{
 						Requests: map[corev1.ResourceName]resource.Quantity{
-							"cpu":    resource.MustParse("500m"),
-							"memory": resource.MustParse("300Mi"),
-						},
-						Limits: map[corev1.ResourceName]resource.Quantity{
 							"cpu":    resource.MustParse("500m"),
 							"memory": resource.MustParse("300Mi"),
 						},
@@ -476,10 +468,6 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 				for _, c := range pp.Spec.Containers {
 					if c.Name == constants.ContainerNameOauth2Proxy {
 						Expect(c.Resources).To(Equal(corev1.ResourceRequirements{
-							Limits: corev1.ResourceList{
-								"cpu":    resource.MustParse("100m"),
-								"memory": resource.MustParse("100Mi"),
-							},
 							Requests: corev1.ResourceList{
 								"cpu":    resource.MustParse("5m"),
 								"memory": resource.MustParse("32Mi"),
@@ -512,10 +500,6 @@ var _ = Describe("Oidc Apps MutatingAdmission Framework Test", func() {
 				for _, c := range pp.Spec.Containers {
 					if c.Name == constants.ContainerNameKubeRbacProxy {
 						expected := corev1.ResourceRequirements{
-							Limits: map[corev1.ResourceName]resource.Quantity{
-								"cpu":    resource.MustParse("100m"),
-								"memory": resource.MustParse("100Mi"),
-							},
 							Requests: map[corev1.ResourceName]resource.Quantity{
 								"cpu":    resource.MustParse("5m"),
 								"memory": resource.MustParse("32Mi"),


### PR DESCRIPTION
This PR removes the side-car container limits. Resource requests remains the same.

```other operator
Side-car containers resource limits are now removed.
```
