### PR TITLE
Update oauth2-proxy to v7.10.0

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -11,4 +11,4 @@ images:
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: "v7.9.0"
+    tag: "v7.10.0"


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR brings oauth2-proxy version: v7.10.0, containing security fixes, dependencies updates and bug fixes.
- [oauth2-proxy v7.10.0 release notes](https://github.com/oauth2-proxy/oauth2-proxy/releases/tag/v7.10.0)


```operator dependency
oauth2-proxy v7.10.0 is the default the authentication container image in oidc-apps-controller
```
