### PR TITLE
Update authentication and authorization proxies

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -5,8 +5,8 @@ images:
   - name: kube-rbac-proxy-watcher
     sourceRepository: github.com/gardener/kube-rbac-proxy-watcher
     repository: europe-docker.pkg.dev/gardener-project/releases/gardener/extensions/kube-rbac-proxy-watcher
-    tag: "v0.1.12"
+    tag: "v0.1.13"
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: "v7.10.0"
+    tag: "v7.12.0"


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area oidc-apps

**What this PR does / why we need it**:
This PR updates the authentication and authorization proxy components by bumping the versions of two key images: `kube-rbac-proxy-watcher` from v0.1.12 to v0.1.13 and `oauth2-proxy` from v7.10.0 to v7.12.0. These updates ensure the OIDC apps extension uses the latest stable versions of these critical security components, bringing in potential bug fixes, security patches, and performance improvements.

**Code changes**:
- Updated `kube-rbac-proxy-watcher` image tag from `v0.1.12` to `v0.1.13`
- Updated `oauth2-proxy` image tag from `v7.10.0` to `v7.12.0`
- Changes made in `imagevector/images.yaml` configuration file

**Additional context**:
These are routine dependency updates for authentication and authorization proxy components used in the OIDC apps extension. Both components are essential for secure access control and authentication flows.

**Which issue(s) this PR fixes**:
<!-- No specific issue mentioned -->

**Special notes for your reviewer**:
Please verify that the updated versions are compatible with the current deployment configurations and that no breaking changes were introduced in the minor version bumps.

**Release note**:
```other operator
Updated kube-rbac-proxy-watcher to v0.1.13 and oauth2-proxy to v7.12.0 for improved security and stability
```

- [ ] 🔄 Regenerate Summary

