### PR TITLE
Remove special handling for prometheus vpa (old todo)

### DIFF
--- a/pkg/controllers/modifiers.go
+++ b/pkg/controllers/modifiers.go
@@ -521,24 +521,6 @@ func patchVpa(ctx context.Context, c client.Client, object client.Object) error 
 		}
 	}
 
-	// TODO(nickytd): Remove this block once PR https://github.com/gardener/gardener/pull/9244 is merged
-	if len(vpa.Items) == 0 {
-		prometheusVpa := &autoscalerv1.VerticalPodAutoscaler{}
-		if err := c.Get(ctx, types.NamespacedName{Name: "prometheus-vpa", Namespace: object.GetNamespace()}, prometheusVpa); client.IgnoreNotFound(err) != nil {
-			log.FromContext(ctx).Error(err, "cannot get prometheus-vpa")
-
-			return nil
-		}
-
-		if prometheusVpa.GetName() == "prometheus-vpa" {
-			if err := c.Patch(ctx, prometheusVpa, client.RawPatch(types.MergePatchType, []byte(`{}`))); err != nil {
-				return fmt.Errorf("failed to patch vpa: %w", err)
-			}
-
-			log.FromContext(ctx).Info("trigger patch", "vpa", prometheusVpa.GetName())
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
**How to categorize this PR?**
/kind cleanup
/area oidc-apps

**What this PR does / why we need it**:
This PR removes special handling code for the prometheus VPA (Vertical Pod Autoscaler) that was marked as a temporary workaround. The removed code was handling the case where no VPA items were found by specifically looking for and patching a "prometheus-vpa" resource. This cleanup eliminates technical debt by removing the TODO and associated temporary workaround code.

**Code changes**:
- Removed a conditional block in `pkg/controllers/modifiers.go` that provided special handling for "prometheus-vpa" 
- Eliminated the fallback logic that would patch the prometheus VPA when no VPA items were found in the main processing loop
- Removed the TODO comment referencing the gardener PR that has presumably been merged

**Additional context**:
The removed code was marked with a TODO comment indicating it should be removed once PR https://github.com/gardener/gardener/pull/9244 was merged. This suggests the upstream changes have been integrated and the workaround is no longer needed.

**Which issue(s) this PR fixes**:
<!-- No specific issue number provided -->

**Special notes for your reviewer**:
Please verify that the referenced gardener PR #9244 has indeed been merged and that this special prometheus VPA handling is no longer required.

**Release note**:
```other developer
Removed deprecated special handling for prometheus VPA that was marked as temporary workaround
```

- [ ] 🔄 Regenerate Summary

