### PR TITLE
Update oauth2 proxy

### DIFF
--- a/imagevector/images.yaml
+++ b/imagevector/images.yaml
@@ -9,4 +9,4 @@ images:
   - name: oauth2-proxy
     sourceRepository: github.com/oauth2-proxy/oauth2-proxy
     repository: quay.io/oauth2-proxy/oauth2-proxy
-    tag: "v7.12.0"
+    tag: "v7.13.0"


### PR DESCRIPTION
**How to categorize this PR?**
/kind enhancement
/area oidc-apps

**What this PR does / why we need it**:
This PR updates the oauth2-proxy image version from v7.12.0 to v7.13.0 in the image vector configuration. This ensures that the OIDC apps extension uses the latest stable release of oauth2-proxy, which may include bug fixes, security patches, and minor improvements.

**Code changes**:
- Updated the `oauth2-proxy` image tag in `imagevector/images.yaml` from `v7.12.0` to `v7.13.0`

**Release note**:
```other dependency
The oauth2-proxy image has been updated from v7.12.0 to v7.13.0.
```

