### PR TITLE
Update example

### DIFF
--- a/example/provider-local/02-check_environment.sh
+++ b/example/provider-local/02-check_environment.sh
@@ -59,10 +59,10 @@ function check_provider_local {
     fi
 
     ipam=$(docker network inspect kind -f "{{range .IPAM.Config}}{{.Subnet}} {{end}}")
-    if grep -q "172.18.0.0/16" <<< $ipam ; then
-        printf '\u2714 "172.18.0.0/16 subnet found\n'
+    if grep -q "172.18.0.0/24" <<< $ipam ; then
+        printf '\u2714 "172.18.0.0/24 subnet found\n'
     else
-        printf '\u274c "172.18.0.0/16 subnet not found... TODO\n' && exit
+        printf '\u274c "172.18.0.0/24 subnet not found... TODO\n' && exit
     fi
 
     garden=$(docker network inspect kind -f "{{range .Containers}}{{.Name}} {{end}}")


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area oidc-apps

**What this PR does / why we need it**:
This PR fixes an inconsistency in the subnet mask validation for the local provider environment check script. The script was checking for a `/16` subnet mask but should validate against the `/24` subnet mask that is actually used by the kind network configuration.

**Code changes**:
- Updated subnet validation in `example/provider-local/02-check_environment.sh` from `172.18.0.0/16` to `172.18.0.0/24` in both the success message and error message
- Ensures consistency between the expected subnet mask and the actual kind network configuration

**Additional context**:
This is a minor fix that corrects the validation logic to match the actual network configuration used in the local development setup.

**Which issue(s) this PR fixes**:
N/A

**Special notes for your reviewer**:
This change only affects the validation script for local development environments and does not impact production code or functionality.

**Release note**:
```bugfix developer
Fixed subnet mask validation in local provider environment check script from /16 to /24
```

- [ ] 🔄 Regenerate and Update Summary

