### PR TITLE
Support host prefix in httproutes

### DIFF
--- a/pkg/webhook/modifiers.go
+++ b/pkg/webhook/modifiers.go
@@ -30,7 +30,7 @@ func addAnnotations(object client.Object) {
 	}
 
 	annotations[constants.AnnotationKey] = object.GetName()
-	annotations[constants.AnnotationHostKey] = configuration.GetOIDCAppsControllerConfig().GetHost(object)
+	annotations[constants.AnnotationHostKey] = resolveHost(object)
 	annotations[constants.AnnotationTargetKey] = configuration.GetOIDCAppsControllerConfig().GetUpstreamTarget(object)
 	annotations[constants.AnnotationSuffixKey] = fetchTargetSuffix(object)
 	annotations[constants.AnnotationOauth2SecertCehcksumKey] = get2ProxySecretChecksum(object)
@@ -488,4 +488,13 @@ func shallAddOidcCaSecretName(object client.Object) bool {
 	}
 
 	return configuration.GetOIDCAppsControllerConfig().GetOidcCASecretName(object) != ""
+}
+
+func resolveHost(object client.Object) string {
+	cfg := configuration.GetOIDCAppsControllerConfig()
+	if cfg.IsHTTPRouteEnabled() {
+		return cfg.GetHTTPRouteHost(object)
+	}
+
+	return cfg.GetHost(object)
 }

--- a/pkg/webhook/pod-webhook.go
+++ b/pkg/webhook/pod-webhook.go
@@ -74,7 +74,7 @@ func (p *PodMutator) Handle(ctx context.Context, req webhook.AdmissionRequest) w
 	// Add required annotations to pod spec template
 	addPodAnnotations(patch,
 		map[string]string{
-			constants.AnnotationHostKey: configuration.GetOIDCAppsControllerConfig().GetHost(owner),
+			constants.AnnotationHostKey: resolveHost(owner),
 		},
 	)
 
@@ -144,7 +144,7 @@ func (p *PodMutator) Handle(ctx context.Context, req webhook.AdmissionRequest) w
 	// URL needs to reflect the target pod index. When the redirect URL is constructed the pod index is appended to the
 	// host name.
 	if present {
-		hostPrefix := configuration.GetOIDCAppsControllerConfig().GetHost(owner)
+		hostPrefix := resolveHost(owner)
 		if configuration.GetOIDCAppsControllerConfig().GetRedirectURL(owner) != "" {
 			hostPrefix = configuration.GetOIDCAppsControllerConfig().GetRedirectURL(owner)
 			// It does container https:// prefix and /oauth2/callback suffix

--- a/pkg/webhook/test/modifiers_test.go
+++ b/pkg/webhook/test/modifiers_test.go
@@ -422,6 +422,128 @@ var _ = Describe("Cookie Secret Deterministic Generation Tests", func() {
 		})
 	})
 
+	Context("when HTTPRoute is enabled, host annotation uses HTTPRoute hostPrefix", func() {
+		var (
+			deployment      *appsv1.Deployment
+			replicaSet      *appsv1.ReplicaSet
+			pod             *corev1.Pod
+			localPodWebhook *webhook.PodMutator
+			savedGlobal     configuration.Global
+			savedTargets    []configuration.Target
+		)
+
+		BeforeEach(func() {
+			deployment = &appsv1.Deployment{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "Deployment",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx",
+					Namespace: "nginx",
+					Labels:    map[string]string{"app": "nginx"},
+					UID:       "deployment-uid-httproute",
+				},
+			}
+			replicaSet = &appsv1.ReplicaSet{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "apps/v1",
+					Kind:       "ReplicaSet",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-rs-0001",
+					Namespace: "nginx",
+					UID:       "replicaset-uid-httproute",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "Deployment",
+							Name:       "nginx",
+							UID:        "deployment-uid-httproute",
+						},
+					},
+				},
+			}
+			pod = &corev1.Pod{
+				TypeMeta: metav1.TypeMeta{
+					APIVersion: "v1",
+					Kind:       "Pod",
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "nginx-pod-1",
+					Namespace: "nginx",
+					UID:       "pod-uid-httproute",
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							APIVersion: "apps/v1",
+							Kind:       "ReplicaSet",
+							Name:       "nginx-rs-0001",
+							UID:        "replicaset-uid-httproute",
+						},
+					},
+				},
+			}
+
+			s := runtime.NewScheme()
+			err := scheme.AddToScheme(s)
+			Expect(err).NotTo(HaveOccurred())
+
+			fakeClient := fake.NewClientBuilder().
+				WithScheme(s).
+				WithObjects(deployment, replicaSet, pod).
+				Build()
+
+			cfg := configuration.GetOIDCAppsControllerConfig()
+			savedGlobal = cfg.Global
+			savedTargets = cfg.Targets
+
+			cfg.Global = configuration.Global{
+				DomainName: "example.org",
+				HTTPRoutes: &configuration.HTTPRoutesGlobalConf{Enabled: true},
+				Oauth2Proxy: &configuration.Oauth2ProxyConfig{
+					ClientID:      "client-id",
+					ClientSecret:  "client-secret",
+					OidcIssuerURL: "https://oidc-provider.org",
+				},
+			}
+			cfg.Targets = []configuration.Target{
+				{
+					Name: "nginx",
+					LabelSelector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{"app": "nginx"},
+					},
+					HTTPRoute: &configuration.HTTPRouteConf{
+						Create:     true,
+						HostPrefix: "my-httproute-prefix",
+					},
+				},
+			}
+			cfg.SetClient(fakeClient)
+
+			localPodWebhook = &webhook.PodMutator{
+				Client:  fakeClient,
+				Decoder: admission.NewDecoder(s),
+			}
+		})
+
+		It("should set the host annotation with the HTTPRoute hostPrefix", func() {
+			patchedPod := patchPodWithWebhook(pod, localPodWebhook)
+
+			hostAnnotation := patchedPod.GetAnnotations()[constants.AnnotationHostKey]
+			Expect(hostAnnotation).NotTo(BeEmpty(), "Host annotation should be set")
+			Expect(hostAnnotation).To(HavePrefix("my-httproute-prefix-"),
+				"Host annotation should use the HTTPRoute hostPrefix")
+			Expect(hostAnnotation).To(HaveSuffix(".example.org"),
+				"Host annotation should include the global domain")
+		})
+
+		AfterEach(func() {
+			cfg := configuration.GetOIDCAppsControllerConfig()
+			cfg.Global = savedGlobal
+			cfg.Targets = savedTargets
+		})
+	})
+
 	Context("VPA in-place update scenario integration test", func() {
 		var (
 			deployment      *appsv1.Deployment


### PR DESCRIPTION
**How to categorize this PR?**
/kind bug
/area oidc-apps

**What this PR does / why we need it**:
This PR fixes the host annotation resolution in the webhook mutator to correctly use the HTTPRoute `hostPrefix` when HTTPRoute is enabled. Previously, the `AnnotationHostKey` annotation was always set using `GetHost()`, ignoring the HTTPRoute-specific host configuration. A new `resolveHost()` helper function was introduced that checks whether HTTPRoute is enabled and delegates to `GetHTTPRouteHost()` accordingly, falling back to `GetHost()` otherwise.

**Code changes**:
- `pkg/webhook/modifiers.go`: Replaced direct calls to `cfg.GetHost(object)` in `addAnnotations()` with the new `resolveHost()` helper. Added `resolveHost()` function that returns `cfg.GetHTTPRouteHost(object)` when HTTPRoute is enabled, otherwise falls back to `cfg.GetHost(object)`.
- `pkg/webhook/pod-webhook.go`: Updated two call sites in the pod webhook handler (pod annotations and statefulset host prefix resolution) to use `resolveHost(owner)` instead of `configuration.GetOIDCAppsControllerConfig().GetHost(owner)`.
- `pkg/webhook/test/modifiers_test.go`: Added a new test context verifying that when HTTPRoute is enabled and a target is configured with an `HTTPRoute.HostPrefix`, the host annotation on the mutated pod correctly uses the HTTPRoute `hostPrefix` (prefixed and suffixed with the global domain).

**Additional context**:
No breaking changes. The fix is backward compatible — when HTTPRoute is not enabled, behavior is unchanged.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
```bugfix operator
Fixed host annotation resolution in the pod webhook to correctly use the HTTPRoute hostPrefix when HTTPRoute is enabled, instead of always falling back to the generic host configuration.
```

- [ ] 🔄 Regenerate and Update Summary


---
📬 [Subscribe to the Hyperspace PR Bot DL](https://url.sap/451kgs) to get the latest announcements and pilot features!


<details>
<summary>PR Bot Information</summary>

**Version:** `1.20.11` | 📖 [Documentation](https://url.sap/dy9ocn) | 🚨 [Create Incident](https://url.sap/budnv9) | 💬 [Feedback](https://url.sap/my4dn3)

- Event Trigger: `issue_comment.edited`
- Correlation ID: `925ce1b0-3709-11f1-8cdf-82da7896af25`
</details>
