### PR TITLE
config(ocm): transfer repo responsibility to bobi-wan

### DIFF
--- a/.ocm/base-component.yaml
+++ b/.ocm/base-component.yaml
@@ -1,5 +1,10 @@
 # SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 # SPDX-License-Identifier: Apache-2.0
+
+labels:
+  - name: cloud.gardener.cnudie/responsibles
+    value:
+      - type: codeowners
 main-source:
   labels:
     - name: cloud.gardener.cnudie/dso/scanning-hints/source_analysis/v1

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,2 @@
 # oidc-apps-controller maintainers
-*   @nickytd
+*   @bobi-wan


### PR DESCRIPTION
I (bobi-wan) will most likely be doing the bulk of future development in this repo, so I don't want nickytd to get spammed. In particular, repo responsibility is linked to the ODG vulnerability findings, which should come directly to me.

<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Moves repository responsibility to bobi-wan, as most future findings/requests should go to him.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:
If we decide to create a team and make it responsible, here are the reference docs:
https://pages.github.tools.sap/kubernetes/compliance-reporting/ocm-labels/responsibles.html

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```other developer
Responsibility transfer
```
