### PR TITLE
Delete stale ingress resources

### DIFF
--- a/pkg/certificates/manager.go
+++ b/pkg/certificates/manager.go
@@ -160,7 +160,7 @@ func (c *certManager) Start(ctx context.Context) error {
 }
 
 // setupWebhooksCABundles is invoked during runnable initialization and before the controller manager Start method is called.
-// The purpose is to generate an initial set of CA nad TLS certificates bundle and to update the webhook CABundle resource
+// The purpose is to generate an initial set of CA and TLS certificates bundle and to update the webhook CABundle resource
 // Since the client.Client is not present at this moment, we need to construct a new client.
 func (c *certManager) setupWebhooksCABundles(ctx context.Context, config *rest.Config) error {
 	clientset, err := kubernetes.NewForConfig(config)

--- a/pkg/controllers/cleanup.go
+++ b/pkg/controllers/cleanup.go
@@ -1,0 +1,111 @@
+// SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/gardener/oidc-apps-controller/pkg/configuration"
+)
+
+// cleanupInactiveStacks deletes resources from ingress stacks that the target is no longer using.
+// When a stack is already absent it does nothing. Deletion errors are
+// aggregated; missing CRDs are tolerated (see the fetchOidcApps* helpers).
+func cleanupInactiveStacks(ctx context.Context, c client.Client, target, owner client.Object) error {
+	cfg := configuration.GetOIDCAppsControllerConfig()
+
+	var errs []error
+
+	_log := log.FromContext(ctx).WithValues("target", target.GetName(), "owner", owner.GetName())
+
+	if !cfg.ShallCreateIngress(target) {
+		ingresses, err := fetchOidcAppsIngress(ctx, c, owner)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to list stale ingresses: %w", err))
+		} else {
+			for i := range ingresses.Items {
+				ing := &ingresses.Items[i]
+				if err := c.Delete(ctx, ing); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("failed to delete stale ingress %s/%s: %w", ing.Namespace, ing.Name, err))
+
+					continue
+				}
+
+				_log.V(9).Info("Deleted stale ingress", "name", ing.Name, "namespace", ing.Namespace)
+			}
+		}
+	}
+
+	if !cfg.ShallCreateHTTPRoute(target) {
+		httpRoutes, err := fetchOidcAppsHTTPRoutes(ctx, c, owner)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to list stale httproutes: %w", err))
+		} else {
+			for i := range httpRoutes.Items {
+				route := &httpRoutes.Items[i]
+				if err := c.Delete(ctx, route); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("failed to delete stale httproute %s/%s: %w", route.Namespace, route.Name, err))
+
+					continue
+				}
+
+				_log.V(9).Info("Deleted stale httproute", "name", route.Name, "namespace", route.Namespace)
+			}
+		}
+	}
+
+	if !cfg.ShallCreateIstioGateway(target) {
+		virtualServices, err := fetchOidcAppsVirtualServices(ctx, c, owner)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to list stale virtualservices: %w", err))
+		} else {
+			for _, vs := range virtualServices.Items {
+				if err := c.Delete(ctx, vs); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("failed to delete stale virtualservice %s/%s: %w", vs.Namespace, vs.Name, err))
+
+					continue
+				}
+
+				_log.V(9).Info("Deleted stale virtualservice", "name", vs.Name, "namespace", vs.Namespace)
+			}
+		}
+
+		gateways, err := fetchOidcAppsIstioGateways(ctx, c, owner)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to list stale gateways: %w", err))
+		} else {
+			for _, gw := range gateways.Items {
+				if err := c.Delete(ctx, gw); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("failed to delete stale gateway %s/%s: %w", gw.Namespace, gw.Name, err))
+
+					continue
+				}
+
+				_log.V(9).Info("Deleted stale gateway", "name", gw.Name, "namespace", gw.Namespace)
+			}
+		}
+
+		destinationRules, err := fetchOidcAppsDestinationRules(ctx, c, owner)
+		if err != nil {
+			errs = append(errs, fmt.Errorf("failed to list stale destinationrules: %w", err))
+		} else {
+			for _, dr := range destinationRules.Items {
+				if err := c.Delete(ctx, dr); client.IgnoreNotFound(err) != nil {
+					errs = append(errs, fmt.Errorf("failed to delete stale destinationrule %s/%s: %w", dr.Namespace, dr.Name, err))
+
+					continue
+				}
+
+				_log.V(9).Info("Deleted stale destinationrule", "name", dr.Name, "namespace", dr.Namespace)
+			}
+		}
+	}
+
+	return errors.Join(errs...)
+}

--- a/pkg/controllers/modifiers.go
+++ b/pkg/controllers/modifiers.go
@@ -18,7 +18,9 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/json"
 	autoscalerv1 "k8s.io/autoscaler/vertical-pod-autoscaler/pkg/apis/autoscaling.k8s.io/v1"
@@ -83,12 +85,11 @@ func fetchOidcAppsIngress(ctx context.Context, c client.Client, object client.Ob
 	return &networkingv1.IngressList{Items: ownedIngresses}, nil
 }
 
+// fetchOidcAppsHTTPRoutes lists HTTPRoutes in the object's namespace that are owned by it.
+// Returns an empty list if the HTTPRoute CRD is not installed in the cluster, so callers
+// (reconcile and cleanup) work whether or not the global HTTPRoute support is enabled.
 func fetchOidcAppsHTTPRoutes(ctx context.Context, c client.Client, object client.Object) (*gatewayv1.HTTPRouteList,
 	error) {
-	if !configuration.GetOIDCAppsControllerConfig().IsHTTPRouteEnabled() {
-		return &gatewayv1.HTTPRouteList{}, nil
-	}
-
 	oidcHTTPRoutes := &gatewayv1.HTTPRouteList{}
 
 	if err := c.List(ctx, oidcHTTPRoutes,
@@ -99,7 +100,11 @@ func fetchOidcAppsHTTPRoutes(ctx context.Context, c client.Client, object client
 			}),
 		},
 	); err != nil {
-		return oidcHTTPRoutes, client.IgnoreNotFound(err)
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) || runtime.IsNotRegisteredError(err) {
+			return &gatewayv1.HTTPRouteList{}, nil
+		}
+
+		return oidcHTTPRoutes, err
 	}
 
 	ownedHTTPRoutes := make([]gatewayv1.HTTPRoute, 0, len(oidcHTTPRoutes.Items))
@@ -113,12 +118,10 @@ func fetchOidcAppsHTTPRoutes(ctx context.Context, c client.Client, object client
 	return &gatewayv1.HTTPRouteList{Items: ownedHTTPRoutes}, nil
 }
 
+// fetchOidcAppsVirtualServices lists VirtualServices in the object's namespace that are owned by it.
+// Returns an empty list if the VirtualService CRD is not installed in the cluster.
 func fetchOidcAppsVirtualServices(ctx context.Context, c client.Client, object client.Object) (*istioclientnetv1.VirtualServiceList,
 	error) {
-	if !configuration.GetOIDCAppsControllerConfig().IsIstioGatewayEnabled() {
-		return &istioclientnetv1.VirtualServiceList{}, nil
-	}
-
 	oidcVirtualServices := &istioclientnetv1.VirtualServiceList{}
 
 	if err := c.List(ctx, oidcVirtualServices,
@@ -129,7 +132,11 @@ func fetchOidcAppsVirtualServices(ctx context.Context, c client.Client, object c
 			}),
 		},
 	); err != nil {
-		return oidcVirtualServices, client.IgnoreNotFound(err)
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) || runtime.IsNotRegisteredError(err) {
+			return &istioclientnetv1.VirtualServiceList{}, nil
+		}
+
+		return oidcVirtualServices, err
 	}
 
 	ownedVirtualServices := make([]*istioclientnetv1.VirtualService, 0, len(oidcVirtualServices.Items))
@@ -143,12 +150,10 @@ func fetchOidcAppsVirtualServices(ctx context.Context, c client.Client, object c
 	return &istioclientnetv1.VirtualServiceList{Items: ownedVirtualServices}, nil
 }
 
+// fetchOidcAppsIstioGateways lists Istio Gateways in the object's namespace that are owned by it.
+// Returns an empty list if the Gateway CRD is not installed in the cluster.
 func fetchOidcAppsIstioGateways(ctx context.Context, c client.Client, object client.Object) (*istioclientnetv1.GatewayList,
 	error) {
-	if !configuration.GetOIDCAppsControllerConfig().IsIstioGatewayEnabled() {
-		return &istioclientnetv1.GatewayList{}, nil
-	}
-
 	oidcGateways := &istioclientnetv1.GatewayList{}
 
 	if err := c.List(ctx, oidcGateways,
@@ -159,7 +164,11 @@ func fetchOidcAppsIstioGateways(ctx context.Context, c client.Client, object cli
 			}),
 		},
 	); err != nil {
-		return oidcGateways, client.IgnoreNotFound(err)
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) || runtime.IsNotRegisteredError(err) {
+			return &istioclientnetv1.GatewayList{}, nil
+		}
+
+		return oidcGateways, err
 	}
 
 	ownedGateways := make([]*istioclientnetv1.Gateway, 0, len(oidcGateways.Items))
@@ -173,12 +182,10 @@ func fetchOidcAppsIstioGateways(ctx context.Context, c client.Client, object cli
 	return &istioclientnetv1.GatewayList{Items: ownedGateways}, nil
 }
 
+// fetchOidcAppsDestinationRules lists DestinationRules in the object's namespace that are owned by it.
+// Returns an empty list if the DestinationRule CRD is not installed in the cluster.
 func fetchOidcAppsDestinationRules(ctx context.Context, c client.Client, object client.Object) (*istioclientnetv1.DestinationRuleList,
 	error) {
-	if !configuration.GetOIDCAppsControllerConfig().IsIstioGatewayEnabled() {
-		return &istioclientnetv1.DestinationRuleList{}, nil
-	}
-
 	oidcDestinationRules := &istioclientnetv1.DestinationRuleList{}
 
 	if err := c.List(ctx, oidcDestinationRules,
@@ -189,7 +196,11 @@ func fetchOidcAppsDestinationRules(ctx context.Context, c client.Client, object 
 			}),
 		},
 	); err != nil {
-		return oidcDestinationRules, client.IgnoreNotFound(err)
+		if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) || runtime.IsNotRegisteredError(err) {
+			return &istioclientnetv1.DestinationRuleList{}, nil
+		}
+
+		return oidcDestinationRules, err
 	}
 
 	ownedDestinationRules := make([]*istioclientnetv1.DestinationRule, 0, len(oidcDestinationRules.Items))
@@ -380,6 +391,10 @@ func reconcileDeploymentDependencies(ctx context.Context, c client.Client, objec
 	}
 
 	if err = reconcileIstioDestinationRuleForDeployment(ctx, c, object); err != nil {
+		return err
+	}
+
+	if err = cleanupInactiveStacks(ctx, c, object, object); err != nil {
 		return err
 	}
 
@@ -685,6 +700,10 @@ func reconcileStatefulSetDependencies(ctx context.Context, c client.Client, obje
 		}
 
 		if err = reconcileIstioDestinationRuleForStatefulSetPod(ctx, c, &pod, object); err != nil {
+			return err
+		}
+
+		if err = cleanupInactiveStacks(ctx, c, object, &pod); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
Currently, when an existing target is switched from one stack to another (for example Ingress to Istio),
the resources for the old stack are left in the cluster. Those are stale and should be removed. This PR adds the needed functionality for that.
The resources are identified through the owner reference, which is:
- the target deployment when the target IS a deployment
- the pod when the target is a stateful set (done for every pod in the statefulset)

The logic for different resources is identical along both files.

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Cleanup of stale resources
```
