### PR TITLE
Remove gopkg.in/yaml.v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,15 @@ IMAGE_TAG                   := $(EFFECTIVE_VERSION)
 $(TOOLS_DIR):
 	@mkdir -p $(TOOLS_DIR)
 
+# Extracted for easier use by targets
+define check-git-clean
+@if [ -n "$$(git status --porcelain $(SRC_DIRS))" ]; then \
+    echo "Error: $(1) produced changes. Please run 'make $(1)' locally and commit."; \
+    git --no-pager diff $(SRC_DIRS); \
+    exit 1; \
+fi
+endef
+
 #########################################
 # Targets                               #
 #########################################
@@ -128,8 +137,9 @@ tidy:
 
 .PHONY: gci
 gci: tidy
-	@echo "Running gci..."
+	@echo "Running $@..."
 	@$(GO_TOOL) gci write $(GCI_OPT) $(SRC_DIRS)
+	$(call check-git-clean,$@)
 
 .PHONY: fmt
 fmt: tidy
@@ -137,16 +147,18 @@ fmt: tidy
 	@$(GO_TOOL) golangci-lint fmt \
     	--config=$(REPO_ROOT)/.golangci.yaml \
     	$(SRC_DIRS)
+	$(call check-git-clean,$@)
 
 .PHONY: check-go-fix
 check-go-fix: tidy
-	@echo "Running go fix..."
+	@echo "Running $@..."
 	@go fix $(SRC_DIRS)/...
-	@if [ -n "$$(git status --porcelain $(SRC_DIRS))" ]; then \
-		echo "Error: go fix produced changes. Please run 'go fix ./...' and commit the changes."; \
-		git --no-pager diff; \
-		exit 1; \
-	fi
+	# @if [ -n "$$(git status --porcelain $(SRC_DIRS))" ]; then \
+	# 	echo "Error: go fix produced changes. Please run 'go fix ./...' and commit the changes."; \
+	# 	git --no-pager diff; \
+	# 	exit 1; \
+	# fi
+	$(call check-git-clean,$@)
 
 .PHONY: check
 check: tidy fmt gci lint
@@ -159,8 +171,8 @@ lint: tidy
 		$(SRC_DIRS)
 
 # same as above, but applies the changes for linters and formatters together
-.PHONY: fix
-fix: tidy
+.PHONY: lint-fix
+lint-fix: tidy
 	@echo "Running $@..."
 	@$(GO_TOOL) golangci-lint run \
 		--fix \

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,6 @@ require (
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/mock v0.6.0
 	gopkg.in/yaml.v3 v3.0.1
-	gopkg.in/yaml.v3 v3.0.1
 	istio.io/api v1.30.2
 	istio.io/client-go v1.30.2
 	k8s.io/api v0.36.2

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/mock v0.6.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	gopkg.in/yaml.v3 v3.0.1
 	istio.io/api v1.30.2
 	istio.io/client-go v1.30.2

--- a/go.sum
+++ b/go.sum
@@ -196,8 +196,6 @@ gopkg.in/evanphx/json-patch.v4 v4.13.0 h1:czT3CmqEaQ1aanPc5SdlgQrrEIb8w/wwCvWWnf
 gopkg.in/evanphx/json-patch.v4 v4.13.0/go.mod h1:p8EYWUEYMpynmqDbY58zCKCFZw8pRWMG4EsWvDvM72M=
 gopkg.in/inf.v0 v0.9.1 h1:73M5CoZyi3ZLMOyDlQh031Cx6N9NDJ2Vvfl76EDAgDc=
 gopkg.in/inf.v0 v0.9.1/go.mod h1:cWUDdTG/fYaXco+Dcufb5Vnc6Gp2YChqWtbxRZE0mXw=
-gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
-gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Package configuration handles the configuration of the main component,
-// including target configuration, oauth proxy and rbac proxy. 
+// including target configuration, oauth proxy and rbac proxy.
 package configuration
 
 import (

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -1,6 +1,8 @@
 // SPDX-FileCopyrightText: SAP SE or an SAP affiliate company and Gardener contributors
 // SPDX-License-Identifier: Apache-2.0
 
+// Package configuration handles the configuration of the main component,
+// including target configuration, oauth proxy and rbac proxy. 
 package configuration
 
 import (

--- a/pkg/configuration/resource-attributes-template.go
+++ b/pkg/configuration/resource-attributes-template.go
@@ -6,7 +6,7 @@ package configuration
 import (
 	_ "embed"
 
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 )
 
 //go:embed templates/rbac-proxy-resource-attributes.yaml


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->

**What this PR does / why we need it**:
We are using gopkg.in/yaml.v2 in a singular file: resource-attributes-template.go

This PR removes that reference, making yaml.v2 an indirect dependency and substituting it with yaml.v3.
The APIs aren't fully compatible, but our particular usage (Marshal/Unmarshal with plain field types) allows directly swapping them.
This change comes from Renovate creating a dependency bump from v2 to v3 without the needed code changes.

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Replace gopkg.in/yaml.v2 with gopkg.in/yaml.v3
```
