### PR TITLE
Bump golang runtime to 1.26.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build the Go app
 # including patch version temporarily
-FROM golang:1.26.4 AS builder
+FROM golang:1.26.5 AS builder
 
 # Set up the working directory
 WORKDIR /src


### PR DESCRIPTION
<!-- Please ensure that you do not include company internal information. -->
**What this PR does / why we need it**:
Contains fix for 
https://nvd.nist.gov/vuln/detail/CVE-2026-35051

**Which issue(s) this PR fixes**:

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your release note in the below block.
2. If no release note is required, just write "NONE" within the block.

Format of block header: <category> <target_group>
Possible values:
- category:       breaking|feature|bugfix|doc|other
- target_group:   user|operator|developer|dependency
-->
```feature user
Bump Golang runtime to 1.26.5
```
